### PR TITLE
DBの変更とそれにともなうTweetApiの変更

### DIFF
--- a/app/formats/AccountView.scala
+++ b/app/formats/AccountView.scala
@@ -19,11 +19,12 @@ object AccountView {
 
   implicit val accountViewWrites: Writes[AccountView] = Json.writes[AccountView]
 
-  def from(a: Account#TableElementType): AccountView =
+  def from(a: Account#TableElementType): AccountView = {
     AccountView(
       accountId = a.accountId,
       accountName = a.accountName,
       avatar = a.avatar,
       backgroundImage = a.backgroundImage
     )
+  }
 }

--- a/app/formats/AccountView.scala
+++ b/app/formats/AccountView.scala
@@ -4,6 +4,8 @@ import play.api.libs.json.{Json, OWrites}
 import models.Tables.Account
 
 /**
+  * クライアントで表示用のAccountTableのケースクラス
+  *
   * @author yuito.sato
   */
 case class AccountView(

--- a/app/formats/AccountView.scala
+++ b/app/formats/AccountView.scala
@@ -1,6 +1,6 @@
 package formats
 
-import play.api.libs.json.{Json, OWrites}
+import play.api.libs.json.{Json, Writes}
 import models.Tables.Account
 
 /**
@@ -17,7 +17,7 @@ case class AccountView(
 
 object AccountView {
 
-  implicit val accountViewWrites: OWrites[AccountView] = Json.writes[AccountView]
+  implicit val accountViewWrites: Writes[AccountView] = Json.writes[AccountView]
 
   def from(a: Account#TableElementType): AccountView =
     AccountView(

--- a/app/formats/AccountView.scala
+++ b/app/formats/AccountView.scala
@@ -1,0 +1,27 @@
+package formats
+
+import play.api.libs.json.{Json, OWrites}
+import models.Tables.Account
+
+/**
+  * @author yuito.sato
+  */
+case class AccountView(
+  accountId: Long,
+  accountName: String,
+  avatar: Option[String],
+  backgroundImage: Option[String]
+)
+
+object AccountView {
+
+  implicit val accountViewWrites: OWrites[AccountView] = Json.writes[AccountView]
+
+  def from(a: Account#TableElementType): AccountView =
+    AccountView(
+      accountId = a.accountId,
+      accountName = a.accountName,
+      avatar = a.avatar,
+      backgroundImage = a.backgroundImage
+    )
+}

--- a/app/formats/TweetCommand.scala
+++ b/app/formats/TweetCommand.scala
@@ -10,7 +10,7 @@ import play.api.libs.json.{Json, Reads}
 case class TweetCommand(
   tweetText: String,
   versionNo: Option[Long],
-  accountIds: Seq[Long]
+  accountIds: Option[Seq[Long]]
 )
 
 object TweetCommand {

--- a/app/formats/TweetCommand.scala
+++ b/app/formats/TweetCommand.scala
@@ -9,7 +9,8 @@ import play.api.libs.json.{Json, Reads}
   */
 case class TweetCommand(
   tweetText: String,
-  versionNo: Option[Long]
+  versionNo: Option[Long],
+  accountIds: Seq[Long]
 )
 
 object TweetCommand {

--- a/app/formats/TweetView.scala
+++ b/app/formats/TweetView.scala
@@ -12,24 +12,22 @@ import play.api.libs.json._
   */
 case class TweetView(
   tweetId: Long,
-  memberId: Long,
   tweetText: String,
   registerDatetime: LocalDateTime,
   versionNo: Long,
-  memberName: String
+  accounts: Seq[AccountView]
 )
 
 object TweetView {
 
   implicit val tweetViewWrites: OWrites[TweetView] = Json.writes[TweetView]
 
-  def from(t: Tweet#TableElementType, m: Member#TableElementType): TweetView =
+  def from(t: Tweet#TableElementType, aList: Seq[AccountView]): TweetView =
     TweetView(
       tweetId = t.tweetId,
-      memberId = t.memberId,
       tweetText = t.tweetText,
       registerDatetime = t.registerDatetime.toLocalDateTime,
       versionNo = t.versionNo,
-      memberName = m.memberName
+      accounts = aList
     )
 }

--- a/app/formats/TweetView.scala
+++ b/app/formats/TweetView.scala
@@ -22,12 +22,12 @@ object TweetView {
 
   implicit val tweetViewWrites: Writes[TweetView] = Json.writes[TweetView]
 
-  def from(t: Tweet#TableElementType, aList: Seq[AccountView]): TweetView =
+  def from(tweet: Tweet#TableElementType, accounts: Seq[AccountView]): TweetView =
     TweetView(
-      tweetId = t.tweetId,
-      tweetText = t.tweetText,
-      registerDatetime = t.registerDatetime.toLocalDateTime,
-      versionNo = t.versionNo,
-      accounts = aList
+      tweetId = tweet.tweetId,
+      tweetText = tweet.tweetText,
+      registerDatetime = tweet.registerDatetime.toLocalDateTime,
+      versionNo = tweet.versionNo,
+      accounts = accounts
     )
 }

--- a/app/formats/TweetView.scala
+++ b/app/formats/TweetView.scala
@@ -1,7 +1,7 @@
 package formats
 
 import java.time.LocalDateTime
-import models.Tables.{Member, Tweet}
+import models.Tables.Tweet
 
 import play.api.libs.json._
 

--- a/app/formats/TweetView.scala
+++ b/app/formats/TweetView.scala
@@ -6,7 +6,7 @@ import models.Tables.Tweet
 import play.api.libs.json._
 
 /**
-  * MEMBERテーブルの情報を付加させたTWEETテーブルのケースクラス
+  * クライアントで表示用のTWEETテーブルのケースクラス
   *
   * @author yuito.sato
   */

--- a/app/formats/TweetView.scala
+++ b/app/formats/TweetView.scala
@@ -1,9 +1,9 @@
 package formats
 
 import java.time.LocalDateTime
-import models.Tables.Tweet
 
-import play.api.libs.json._
+import models.Tables.Tweet
+import play.api.libs.json.{Json, Writes}
 
 /**
   * クライアントで表示用のTWEETテーブルのケースクラス
@@ -20,7 +20,7 @@ case class TweetView(
 
 object TweetView {
 
-  implicit val tweetViewWrites: OWrites[TweetView] = Json.writes[TweetView]
+  implicit val tweetViewWrites: Writes[TweetView] = Json.writes[TweetView]
 
   def from(t: Tweet#TableElementType, aList: Seq[AccountView]): TweetView =
     TweetView(

--- a/app/formats/TweetView.scala
+++ b/app/formats/TweetView.scala
@@ -22,7 +22,7 @@ object TweetView {
 
   implicit val tweetViewWrites: Writes[TweetView] = Json.writes[TweetView]
 
-  def from(tweet: Tweet#TableElementType, accounts: Seq[AccountView]): TweetView =
+  def from(tweet: Tweet#TableElementType, accounts: Seq[AccountView]): TweetView = {
     TweetView(
       tweetId = tweet.tweetId,
       tweetText = tweet.tweetText,
@@ -30,4 +30,5 @@ object TweetView {
       versionNo = tweet.versionNo,
       accounts = accounts
     )
+  }
 }

--- a/app/models/Tables.scala
+++ b/app/models/Tables.scala
@@ -14,44 +14,41 @@ trait Tables {
   import slick.jdbc.{GetResult => GR}
 
   /** DDL for all tables. Call .create to execute. */
-  lazy val schema: profile.SchemaDescription = Member.schema ++ MemberFollowing.schema ++ Tweet.schema
+  lazy val schema: profile.SchemaDescription = Account.schema ++ AccountFollowing.schema ++ AccountTweet.schema ++ Member.schema ++ Tweet.schema
   @deprecated("Use .schema instead of .ddl", "3.0")
   def ddl = schema
 
-  /** Entity class storing rows of table Member
-   *  @param memberId Database column MEMBER_ID SqlType(BIGINT), AutoInc, PrimaryKey
-   *  @param memberName Database column MEMBER_NAME SqlType(VARCHAR), Length(50,true)
-   *  @param memberAccount Database column MEMBER_ACCOUNT SqlType(VARCHAR), Length(50,true)
-   *  @param emailAddress Database column EMAIL_ADDRESS SqlType(VARCHAR), Length(50,true)
-   *  @param password Database column PASSWORD SqlType(VARCHAR), Length(200,true)
-   *  @param memberAvatar Database column MEMBER_AVATAR SqlType(VARCHAR), Length(200,true), Default(None)
+  /** Entity class storing rows of table Account
+   *  @param accountId Database column ACCOUNT_ID SqlType(BIGINT), AutoInc, PrimaryKey
+   *  @param memberId Database column MEMBER_ID SqlType(BIGINT)
+   *  @param accountname Database column ACCOUNTNAME SqlType(VARCHAR), Length(50,true)
+   *  @param avatar Database column AVATAR SqlType(VARCHAR), Length(200,true), Default(None)
+   *  @param backgroundImage Database column BACKGROUND_IMAGE SqlType(VARCHAR), Length(200,true), Default(None)
    *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME)
    *  @param updateDatetime Database column UPDATE_DATETIME SqlType(DATETIME)
    *  @param versionNo Database column VERSION_NO SqlType(BIGINT) */
-  case class MemberRow(memberId: Long, memberName: String, memberAccount: String, emailAddress: String, password: String, memberAvatar: Option[String] = None, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
-  /** GetResult implicit for fetching MemberRow objects using plain SQL queries */
-  implicit def GetResultMemberRow(implicit e0: GR[Long], e1: GR[String], e2: GR[Option[String]], e3: GR[java.sql.Timestamp]): GR[MemberRow] = GR{
+  case class AccountRow(accountId: Long, memberId: Long, accountname: String, avatar: Option[String] = None, backgroundImage: Option[String] = None, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
+  /** GetResult implicit for fetching AccountRow objects using plain SQL queries */
+  implicit def GetResultAccountRow(implicit e0: GR[Long], e1: GR[String], e2: GR[Option[String]], e3: GR[java.sql.Timestamp]): GR[AccountRow] = GR{
     prs => import prs._
-    MemberRow.tupled((<<[Long], <<[String], <<[String], <<[String], <<[String], <<?[String], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
+    AccountRow.tupled((<<[Long], <<[Long], <<[String], <<?[String], <<?[String], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
   }
-  /** Table description of table MEMBER. Objects of this class serve as prototypes for rows in queries. */
-  class Member(_tableTag: Tag) extends Table[MemberRow](_tableTag, "MEMBER") {
-    def * = (memberId, memberName, memberAccount, emailAddress, password, memberAvatar, registerDatetime, updateDatetime, versionNo) <> (MemberRow.tupled, MemberRow.unapply)
+  /** Table description of table ACCOUNT. Objects of this class serve as prototypes for rows in queries. */
+  class Account(_tableTag: Tag) extends Table[AccountRow](_tableTag, "ACCOUNT") {
+    def * = (accountId, memberId, accountname, avatar, backgroundImage, registerDatetime, updateDatetime, versionNo) <> (AccountRow.tupled, AccountRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = (Rep.Some(memberId), Rep.Some(memberName), Rep.Some(memberAccount), Rep.Some(emailAddress), Rep.Some(password), memberAvatar, Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> MemberRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6, _7.get, _8.get, _9.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? = (Rep.Some(accountId), Rep.Some(memberId), Rep.Some(accountname), avatar, backgroundImage, Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> AccountRow.tupled((_1.get, _2.get, _3.get, _4, _5, _6.get, _7.get, _8.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
-    /** Database column MEMBER_ID SqlType(BIGINT), AutoInc, PrimaryKey */
-    val memberId: Rep[Long] = column[Long]("MEMBER_ID", O.AutoInc, O.PrimaryKey)
-    /** Database column MEMBER_NAME SqlType(VARCHAR), Length(50,true) */
-    val memberName: Rep[String] = column[String]("MEMBER_NAME", O.Length(50,varying=true))
-    /** Database column MEMBER_ACCOUNT SqlType(VARCHAR), Length(50,true) */
-    val memberAccount: Rep[String] = column[String]("MEMBER_ACCOUNT", O.Length(50,varying=true))
-    /** Database column EMAIL_ADDRESS SqlType(VARCHAR), Length(50,true) */
-    val emailAddress: Rep[String] = column[String]("EMAIL_ADDRESS", O.Length(50,varying=true))
-    /** Database column PASSWORD SqlType(VARCHAR), Length(200,true) */
-    val password: Rep[String] = column[String]("PASSWORD", O.Length(200,varying=true))
-    /** Database column MEMBER_AVATAR SqlType(VARCHAR), Length(200,true), Default(None) */
-    val memberAvatar: Rep[Option[String]] = column[Option[String]]("MEMBER_AVATAR", O.Length(200,varying=true), O.Default(None))
+    /** Database column ACCOUNT_ID SqlType(BIGINT), AutoInc, PrimaryKey */
+    val accountId: Rep[Long] = column[Long]("ACCOUNT_ID", O.AutoInc, O.PrimaryKey)
+    /** Database column MEMBER_ID SqlType(BIGINT) */
+    val memberId: Rep[Long] = column[Long]("MEMBER_ID")
+    /** Database column ACCOUNTNAME SqlType(VARCHAR), Length(50,true) */
+    val accountname: Rep[String] = column[String]("ACCOUNTNAME", O.Length(50,varying=true))
+    /** Database column AVATAR SqlType(VARCHAR), Length(200,true), Default(None) */
+    val avatar: Rep[Option[String]] = column[Option[String]]("AVATAR", O.Length(200,varying=true), O.Default(None))
+    /** Database column BACKGROUND_IMAGE SqlType(VARCHAR), Length(200,true), Default(None) */
+    val backgroundImage: Rep[Option[String]] = column[Option[String]]("BACKGROUND_IMAGE", O.Length(200,varying=true), O.Default(None))
     /** Database column REGISTER_DATETIME SqlType(DATETIME) */
     val registerDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("REGISTER_DATETIME")
     /** Database column UPDATE_DATETIME SqlType(DATETIME) */
@@ -59,36 +56,30 @@ trait Tables {
     /** Database column VERSION_NO SqlType(BIGINT) */
     val versionNo: Rep[Long] = column[Long]("VERSION_NO")
 
-    /** Uniqueness Index over (emailAddress) (database name EMAIL_ADDRESS) */
-    val index1 = index("EMAIL_ADDRESS", emailAddress, unique=true)
-    /** Index over (memberAccount) (database name IX_MEMBER_MEMBER_ACCOUNT) */
-    val index2 = index("IX_MEMBER_MEMBER_ACCOUNT", memberAccount)
-    /** Index over (memberName) (database name IX_MEMBER_MEMBER_NAME) */
-    val index3 = index("IX_MEMBER_MEMBER_NAME", memberName)
-    /** Uniqueness Index over (memberAccount) (database name MEMBER_ACCOUNT) */
-    val index4 = index("MEMBER_ACCOUNT", memberAccount, unique=true)
+    /** Foreign key referencing Member (database name FK_ACCOUNT_MEMBER) */
+    lazy val memberFk = foreignKey("FK_ACCOUNT_MEMBER", memberId, Member)(r => r.memberId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   }
-  /** Collection-like TableQuery object for table Member */
-  lazy val Member = new TableQuery(tag => new Member(tag))
+  /** Collection-like TableQuery object for table Account */
+  lazy val Account = new TableQuery(tag => new Account(tag))
 
-  /** Entity class storing rows of table MemberFollowing
+  /** Entity class storing rows of table AccountFollowing
    *  @param memberFollowingId Database column MEMBER_FOLLOWING_ID SqlType(BIGINT), AutoInc, PrimaryKey
    *  @param followerId Database column FOLLOWER_ID SqlType(BIGINT)
    *  @param followeeId Database column FOLLOWEE_ID SqlType(BIGINT)
    *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME)
    *  @param updateDatetime Database column UPDATE_DATETIME SqlType(DATETIME)
    *  @param versionNo Database column VERSION_NO SqlType(BIGINT) */
-  case class MemberFollowingRow(memberFollowingId: Long, followerId: Long, followeeId: Long, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
-  /** GetResult implicit for fetching MemberFollowingRow objects using plain SQL queries */
-  implicit def GetResultMemberFollowingRow(implicit e0: GR[Long], e1: GR[java.sql.Timestamp]): GR[MemberFollowingRow] = GR{
+  case class AccountFollowingRow(memberFollowingId: Long, followerId: Long, followeeId: Long, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
+  /** GetResult implicit for fetching AccountFollowingRow objects using plain SQL queries */
+  implicit def GetResultAccountFollowingRow(implicit e0: GR[Long], e1: GR[java.sql.Timestamp]): GR[AccountFollowingRow] = GR{
     prs => import prs._
-    MemberFollowingRow.tupled((<<[Long], <<[Long], <<[Long], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
+    AccountFollowingRow.tupled((<<[Long], <<[Long], <<[Long], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
   }
-  /** Table description of table MEMBER_FOLLOWING. Objects of this class serve as prototypes for rows in queries. */
-  class MemberFollowing(_tableTag: Tag) extends Table[MemberFollowingRow](_tableTag, "MEMBER_FOLLOWING") {
-    def * = (memberFollowingId, followerId, followeeId, registerDatetime, updateDatetime, versionNo) <> (MemberFollowingRow.tupled, MemberFollowingRow.unapply)
+  /** Table description of table ACCOUNT_FOLLOWING. Objects of this class serve as prototypes for rows in queries. */
+  class AccountFollowing(_tableTag: Tag) extends Table[AccountFollowingRow](_tableTag, "ACCOUNT_FOLLOWING") {
+    def * = (memberFollowingId, followerId, followeeId, registerDatetime, updateDatetime, versionNo) <> (AccountFollowingRow.tupled, AccountFollowingRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = (Rep.Some(memberFollowingId), Rep.Some(followerId), Rep.Some(followeeId), Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> MemberFollowingRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? = (Rep.Some(memberFollowingId), Rep.Some(followerId), Rep.Some(followeeId), Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> AccountFollowingRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column MEMBER_FOLLOWING_ID SqlType(BIGINT), AutoInc, PrimaryKey */
     val memberFollowingId: Rep[Long] = column[Long]("MEMBER_FOLLOWING_ID", O.AutoInc, O.PrimaryKey)
@@ -103,37 +94,112 @@ trait Tables {
     /** Database column VERSION_NO SqlType(BIGINT) */
     val versionNo: Rep[Long] = column[Long]("VERSION_NO")
 
-    /** Foreign key referencing Member (database name FK_MEMBER_FOLLOWEE) */
-    lazy val memberFk1 = foreignKey("FK_MEMBER_FOLLOWEE", followeeId, Member)(r => r.memberId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
-    /** Foreign key referencing Member (database name FK_MEMBER_FOLLOWER) */
-    lazy val memberFk2 = foreignKey("FK_MEMBER_FOLLOWER", followerId, Member)(r => r.memberId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    /** Foreign key referencing Account (database name FK_ACCOUNT_FOLLOWEE_ACCOUNT) */
+    lazy val accountFk1 = foreignKey("FK_ACCOUNT_FOLLOWEE_ACCOUNT", followeeId, Account)(r => r.accountId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    /** Foreign key referencing Account (database name FK_FOLLOWER_ACCOUNT) */
+    lazy val accountFk2 = foreignKey("FK_FOLLOWER_ACCOUNT", followerId, Account)(r => r.accountId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
   }
-  /** Collection-like TableQuery object for table MemberFollowing */
-  lazy val MemberFollowing = new TableQuery(tag => new MemberFollowing(tag))
+  /** Collection-like TableQuery object for table AccountFollowing */
+  lazy val AccountFollowing = new TableQuery(tag => new AccountFollowing(tag))
+
+  /** Entity class storing rows of table AccountTweet
+   *  @param accountTweetId Database column ACCOUNT_TWEET_ID SqlType(BIGINT), AutoInc, PrimaryKey
+   *  @param accountId Database column ACCOUNT_ID SqlType(BIGINT)
+   *  @param tweetId Database column TWEET_ID SqlType(BIGINT)
+   *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME)
+   *  @param updateDatetime Database column UPDATE_DATETIME SqlType(DATETIME)
+   *  @param versionNo Database column VERSION_NO SqlType(BIGINT) */
+  case class AccountTweetRow(accountTweetId: Long, accountId: Long, tweetId: Long, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
+  /** GetResult implicit for fetching AccountTweetRow objects using plain SQL queries */
+  implicit def GetResultAccountTweetRow(implicit e0: GR[Long], e1: GR[java.sql.Timestamp]): GR[AccountTweetRow] = GR{
+    prs => import prs._
+    AccountTweetRow.tupled((<<[Long], <<[Long], <<[Long], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
+  }
+  /** Table description of table ACCOUNT_TWEET. Objects of this class serve as prototypes for rows in queries. */
+  class AccountTweet(_tableTag: Tag) extends Table[AccountTweetRow](_tableTag, "ACCOUNT_TWEET") {
+    def * = (accountTweetId, accountId, tweetId, registerDatetime, updateDatetime, versionNo) <> (AccountTweetRow.tupled, AccountTweetRow.unapply)
+    /** Maps whole row to an option. Useful for outer joins. */
+    def ? = (Rep.Some(accountTweetId), Rep.Some(accountId), Rep.Some(tweetId), Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> AccountTweetRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+
+    /** Database column ACCOUNT_TWEET_ID SqlType(BIGINT), AutoInc, PrimaryKey */
+    val accountTweetId: Rep[Long] = column[Long]("ACCOUNT_TWEET_ID", O.AutoInc, O.PrimaryKey)
+    /** Database column ACCOUNT_ID SqlType(BIGINT) */
+    val accountId: Rep[Long] = column[Long]("ACCOUNT_ID")
+    /** Database column TWEET_ID SqlType(BIGINT) */
+    val tweetId: Rep[Long] = column[Long]("TWEET_ID")
+    /** Database column REGISTER_DATETIME SqlType(DATETIME) */
+    val registerDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("REGISTER_DATETIME")
+    /** Database column UPDATE_DATETIME SqlType(DATETIME) */
+    val updateDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("UPDATE_DATETIME")
+    /** Database column VERSION_NO SqlType(BIGINT) */
+    val versionNo: Rep[Long] = column[Long]("VERSION_NO")
+
+    /** Foreign key referencing Account (database name FK_ACCOUNT_TWEET_ACCOUNT) */
+    lazy val accountFk = foreignKey("FK_ACCOUNT_TWEET_ACCOUNT", accountId, Account)(r => r.accountId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+    /** Foreign key referencing Tweet (database name FK_ACCOUNT_TWEET_TWEET) */
+    lazy val tweetFk = foreignKey("FK_ACCOUNT_TWEET_TWEET", tweetId, Tweet)(r => r.tweetId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
+  }
+  /** Collection-like TableQuery object for table AccountTweet */
+  lazy val AccountTweet = new TableQuery(tag => new AccountTweet(tag))
+
+  /** Entity class storing rows of table Member
+   *  @param memberId Database column MEMBER_ID SqlType(BIGINT), AutoInc, PrimaryKey
+   *  @param emailAddress Database column EMAIL_ADDRESS SqlType(VARCHAR), Length(50,true)
+   *  @param password Database column PASSWORD SqlType(CHAR), Length(60,false)
+   *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME)
+   *  @param updateDatetime Database column UPDATE_DATETIME SqlType(DATETIME)
+   *  @param versionNo Database column VERSION_NO SqlType(BIGINT) */
+  case class MemberRow(memberId: Long, emailAddress: String, password: String, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
+  /** GetResult implicit for fetching MemberRow objects using plain SQL queries */
+  implicit def GetResultMemberRow(implicit e0: GR[Long], e1: GR[String], e2: GR[java.sql.Timestamp]): GR[MemberRow] = GR{
+    prs => import prs._
+    MemberRow.tupled((<<[Long], <<[String], <<[String], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
+  }
+  /** Table description of table MEMBER. Objects of this class serve as prototypes for rows in queries. */
+  class Member(_tableTag: Tag) extends Table[MemberRow](_tableTag, "MEMBER") {
+    def * = (memberId, emailAddress, password, registerDatetime, updateDatetime, versionNo) <> (MemberRow.tupled, MemberRow.unapply)
+    /** Maps whole row to an option. Useful for outer joins. */
+    def ? = (Rep.Some(memberId), Rep.Some(emailAddress), Rep.Some(password), Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> MemberRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+
+    /** Database column MEMBER_ID SqlType(BIGINT), AutoInc, PrimaryKey */
+    val memberId: Rep[Long] = column[Long]("MEMBER_ID", O.AutoInc, O.PrimaryKey)
+    /** Database column EMAIL_ADDRESS SqlType(VARCHAR), Length(50,true) */
+    val emailAddress: Rep[String] = column[String]("EMAIL_ADDRESS", O.Length(50,varying=true))
+    /** Database column PASSWORD SqlType(CHAR), Length(60,false) */
+    val password: Rep[String] = column[String]("PASSWORD", O.Length(60,varying=false))
+    /** Database column REGISTER_DATETIME SqlType(DATETIME) */
+    val registerDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("REGISTER_DATETIME")
+    /** Database column UPDATE_DATETIME SqlType(DATETIME) */
+    val updateDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("UPDATE_DATETIME")
+    /** Database column VERSION_NO SqlType(BIGINT) */
+    val versionNo: Rep[Long] = column[Long]("VERSION_NO")
+
+    /** Uniqueness Index over (emailAddress) (database name EMAIL_ADDRESS) */
+    val index1 = index("EMAIL_ADDRESS", emailAddress, unique=true)
+  }
+  /** Collection-like TableQuery object for table Member */
+  lazy val Member = new TableQuery(tag => new Member(tag))
 
   /** Entity class storing rows of table Tweet
    *  @param tweetId Database column TWEET_ID SqlType(BIGINT), AutoInc, PrimaryKey
-   *  @param memberId Database column MEMBER_ID SqlType(BIGINT)
    *  @param tweetText Database column TWEET_TEXT SqlType(VARCHAR), Length(140,true)
    *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME)
    *  @param updateDatetime Database column UPDATE_DATETIME SqlType(DATETIME)
    *  @param versionNo Database column VERSION_NO SqlType(BIGINT) */
-  case class TweetRow(tweetId: Long, memberId: Long, tweetText: String, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
+  case class TweetRow(tweetId: Long, tweetText: String, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
   /** GetResult implicit for fetching TweetRow objects using plain SQL queries */
   implicit def GetResultTweetRow(implicit e0: GR[Long], e1: GR[String], e2: GR[java.sql.Timestamp]): GR[TweetRow] = GR{
     prs => import prs._
-    TweetRow.tupled((<<[Long], <<[Long], <<[String], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
+    TweetRow.tupled((<<[Long], <<[String], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
   }
   /** Table description of table TWEET. Objects of this class serve as prototypes for rows in queries. */
   class Tweet(_tableTag: Tag) extends Table[TweetRow](_tableTag, "TWEET") {
-    def * = (tweetId, memberId, tweetText, registerDatetime, updateDatetime, versionNo) <> (TweetRow.tupled, TweetRow.unapply)
+    def * = (tweetId, tweetText, registerDatetime, updateDatetime, versionNo) <> (TweetRow.tupled, TweetRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = (Rep.Some(tweetId), Rep.Some(memberId), Rep.Some(tweetText), Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> TweetRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? = (Rep.Some(tweetId), Rep.Some(tweetText), Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> TweetRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column TWEET_ID SqlType(BIGINT), AutoInc, PrimaryKey */
     val tweetId: Rep[Long] = column[Long]("TWEET_ID", O.AutoInc, O.PrimaryKey)
-    /** Database column MEMBER_ID SqlType(BIGINT) */
-    val memberId: Rep[Long] = column[Long]("MEMBER_ID")
     /** Database column TWEET_TEXT SqlType(VARCHAR), Length(140,true) */
     val tweetText: Rep[String] = column[String]("TWEET_TEXT", O.Length(140,varying=true))
     /** Database column REGISTER_DATETIME SqlType(DATETIME) */
@@ -142,12 +208,6 @@ trait Tables {
     val updateDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("UPDATE_DATETIME")
     /** Database column VERSION_NO SqlType(BIGINT) */
     val versionNo: Rep[Long] = column[Long]("VERSION_NO")
-
-    /** Foreign key referencing Member (database name FK_TWEET_MEMBER) */
-    lazy val memberFk = foreignKey("FK_TWEET_MEMBER", memberId, Member)(r => r.memberId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
-
-    /** Index over (tweetText) (database name IX_TWEET_TWEET_TEXT) */
-    val index1 = index("IX_TWEET_TWEET_TEXT", tweetText)
   }
   /** Collection-like TableQuery object for table Tweet */
   lazy val Tweet = new TableQuery(tag => new Tweet(tag))

--- a/app/models/Tables.scala
+++ b/app/models/Tables.scala
@@ -21,13 +21,13 @@ trait Tables {
   /** Entity class storing rows of table Account
    *  @param accountId Database column ACCOUNT_ID SqlType(BIGINT), AutoInc, PrimaryKey
    *  @param memberId Database column MEMBER_ID SqlType(BIGINT)
-   *  @param accountname Database column ACCOUNTNAME SqlType(VARCHAR), Length(50,true)
+   *  @param accountName Database column ACCOUNT_NAME SqlType(VARCHAR), Length(50,true)
    *  @param avatar Database column AVATAR SqlType(VARCHAR), Length(200,true), Default(None)
    *  @param backgroundImage Database column BACKGROUND_IMAGE SqlType(VARCHAR), Length(200,true), Default(None)
    *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME)
    *  @param updateDatetime Database column UPDATE_DATETIME SqlType(DATETIME)
    *  @param versionNo Database column VERSION_NO SqlType(BIGINT) */
-  case class AccountRow(accountId: Long, memberId: Long, accountname: String, avatar: Option[String] = None, backgroundImage: Option[String] = None, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
+  case class AccountRow(accountId: Long, memberId: Long, accountName: String, avatar: Option[String] = None, backgroundImage: Option[String] = None, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
   /** GetResult implicit for fetching AccountRow objects using plain SQL queries */
   implicit def GetResultAccountRow(implicit e0: GR[Long], e1: GR[String], e2: GR[Option[String]], e3: GR[java.sql.Timestamp]): GR[AccountRow] = GR{
     prs => import prs._
@@ -35,16 +35,16 @@ trait Tables {
   }
   /** Table description of table ACCOUNT. Objects of this class serve as prototypes for rows in queries. */
   class Account(_tableTag: Tag) extends Table[AccountRow](_tableTag, "ACCOUNT") {
-    def * = (accountId, memberId, accountname, avatar, backgroundImage, registerDatetime, updateDatetime, versionNo) <> (AccountRow.tupled, AccountRow.unapply)
+    def * = (accountId, memberId, accountName, avatar, backgroundImage, registerDatetime, updateDatetime, versionNo) <> (AccountRow.tupled, AccountRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = (Rep.Some(accountId), Rep.Some(memberId), Rep.Some(accountname), avatar, backgroundImage, Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> AccountRow.tupled((_1.get, _2.get, _3.get, _4, _5, _6.get, _7.get, _8.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? = (Rep.Some(accountId), Rep.Some(memberId), Rep.Some(accountName), avatar, backgroundImage, Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> AccountRow.tupled((_1.get, _2.get, _3.get, _4, _5, _6.get, _7.get, _8.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column ACCOUNT_ID SqlType(BIGINT), AutoInc, PrimaryKey */
     val accountId: Rep[Long] = column[Long]("ACCOUNT_ID", O.AutoInc, O.PrimaryKey)
     /** Database column MEMBER_ID SqlType(BIGINT) */
     val memberId: Rep[Long] = column[Long]("MEMBER_ID")
-    /** Database column ACCOUNTNAME SqlType(VARCHAR), Length(50,true) */
-    val accountname: Rep[String] = column[String]("ACCOUNTNAME", O.Length(50,varying=true))
+    /** Database column ACCOUNT_NAME SqlType(VARCHAR), Length(50,true) */
+    val accountName: Rep[String] = column[String]("ACCOUNT_NAME", O.Length(50,varying=true))
     /** Database column AVATAR SqlType(VARCHAR), Length(200,true), Default(None) */
     val avatar: Rep[Option[String]] = column[Option[String]]("AVATAR", O.Length(200,varying=true), O.Default(None))
     /** Database column BACKGROUND_IMAGE SqlType(VARCHAR), Length(200,true), Default(None) */

--- a/app/models/Tables.scala
+++ b/app/models/Tables.scala
@@ -66,20 +66,18 @@ trait Tables {
    *  @param memberFollowingId Database column MEMBER_FOLLOWING_ID SqlType(BIGINT), AutoInc, PrimaryKey
    *  @param followerId Database column FOLLOWER_ID SqlType(BIGINT)
    *  @param followeeId Database column FOLLOWEE_ID SqlType(BIGINT)
-   *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME)
-   *  @param updateDatetime Database column UPDATE_DATETIME SqlType(DATETIME)
-   *  @param versionNo Database column VERSION_NO SqlType(BIGINT) */
-  case class AccountFollowingRow(memberFollowingId: Long, followerId: Long, followeeId: Long, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
+   *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME) */
+  case class AccountFollowingRow(memberFollowingId: Long, followerId: Long, followeeId: Long, registerDatetime: java.sql.Timestamp)
   /** GetResult implicit for fetching AccountFollowingRow objects using plain SQL queries */
   implicit def GetResultAccountFollowingRow(implicit e0: GR[Long], e1: GR[java.sql.Timestamp]): GR[AccountFollowingRow] = GR{
     prs => import prs._
-    AccountFollowingRow.tupled((<<[Long], <<[Long], <<[Long], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
+    AccountFollowingRow.tupled((<<[Long], <<[Long], <<[Long], <<[java.sql.Timestamp]))
   }
   /** Table description of table ACCOUNT_FOLLOWING. Objects of this class serve as prototypes for rows in queries. */
   class AccountFollowing(_tableTag: Tag) extends Table[AccountFollowingRow](_tableTag, "ACCOUNT_FOLLOWING") {
-    def * = (memberFollowingId, followerId, followeeId, registerDatetime, updateDatetime, versionNo) <> (AccountFollowingRow.tupled, AccountFollowingRow.unapply)
+    def * = (memberFollowingId, followerId, followeeId, registerDatetime) <> (AccountFollowingRow.tupled, AccountFollowingRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = (Rep.Some(memberFollowingId), Rep.Some(followerId), Rep.Some(followeeId), Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> AccountFollowingRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? = (Rep.Some(memberFollowingId), Rep.Some(followerId), Rep.Some(followeeId), Rep.Some(registerDatetime)).shaped.<>({r=>import r._; _1.map(_=> AccountFollowingRow.tupled((_1.get, _2.get, _3.get, _4.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column MEMBER_FOLLOWING_ID SqlType(BIGINT), AutoInc, PrimaryKey */
     val memberFollowingId: Rep[Long] = column[Long]("MEMBER_FOLLOWING_ID", O.AutoInc, O.PrimaryKey)
@@ -89,10 +87,6 @@ trait Tables {
     val followeeId: Rep[Long] = column[Long]("FOLLOWEE_ID")
     /** Database column REGISTER_DATETIME SqlType(DATETIME) */
     val registerDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("REGISTER_DATETIME")
-    /** Database column UPDATE_DATETIME SqlType(DATETIME) */
-    val updateDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("UPDATE_DATETIME")
-    /** Database column VERSION_NO SqlType(BIGINT) */
-    val versionNo: Rep[Long] = column[Long]("VERSION_NO")
 
     /** Foreign key referencing Account (database name FK_ACCOUNT_FOLLOWEE_ACCOUNT) */
     lazy val accountFk1 = foreignKey("FK_ACCOUNT_FOLLOWEE_ACCOUNT", followeeId, Account)(r => r.accountId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
@@ -106,20 +100,18 @@ trait Tables {
    *  @param accountTweetId Database column ACCOUNT_TWEET_ID SqlType(BIGINT), AutoInc, PrimaryKey
    *  @param accountId Database column ACCOUNT_ID SqlType(BIGINT)
    *  @param tweetId Database column TWEET_ID SqlType(BIGINT)
-   *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME)
-   *  @param updateDatetime Database column UPDATE_DATETIME SqlType(DATETIME)
-   *  @param versionNo Database column VERSION_NO SqlType(BIGINT) */
-  case class AccountTweetRow(accountTweetId: Long, accountId: Long, tweetId: Long, registerDatetime: java.sql.Timestamp, updateDatetime: java.sql.Timestamp, versionNo: Long)
+   *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME) */
+  case class AccountTweetRow(accountTweetId: Long, accountId: Long, tweetId: Long, registerDatetime: java.sql.Timestamp)
   /** GetResult implicit for fetching AccountTweetRow objects using plain SQL queries */
   implicit def GetResultAccountTweetRow(implicit e0: GR[Long], e1: GR[java.sql.Timestamp]): GR[AccountTweetRow] = GR{
     prs => import prs._
-    AccountTweetRow.tupled((<<[Long], <<[Long], <<[Long], <<[java.sql.Timestamp], <<[java.sql.Timestamp], <<[Long]))
+    AccountTweetRow.tupled((<<[Long], <<[Long], <<[Long], <<[java.sql.Timestamp]))
   }
   /** Table description of table ACCOUNT_TWEET. Objects of this class serve as prototypes for rows in queries. */
   class AccountTweet(_tableTag: Tag) extends Table[AccountTweetRow](_tableTag, "ACCOUNT_TWEET") {
-    def * = (accountTweetId, accountId, tweetId, registerDatetime, updateDatetime, versionNo) <> (AccountTweetRow.tupled, AccountTweetRow.unapply)
+    def * = (accountTweetId, accountId, tweetId, registerDatetime) <> (AccountTweetRow.tupled, AccountTweetRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = (Rep.Some(accountTweetId), Rep.Some(accountId), Rep.Some(tweetId), Rep.Some(registerDatetime), Rep.Some(updateDatetime), Rep.Some(versionNo)).shaped.<>({r=>import r._; _1.map(_=> AccountTweetRow.tupled((_1.get, _2.get, _3.get, _4.get, _5.get, _6.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? = (Rep.Some(accountTweetId), Rep.Some(accountId), Rep.Some(tweetId), Rep.Some(registerDatetime)).shaped.<>({r=>import r._; _1.map(_=> AccountTweetRow.tupled((_1.get, _2.get, _3.get, _4.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
     /** Database column ACCOUNT_TWEET_ID SqlType(BIGINT), AutoInc, PrimaryKey */
     val accountTweetId: Rep[Long] = column[Long]("ACCOUNT_TWEET_ID", O.AutoInc, O.PrimaryKey)
@@ -129,10 +121,6 @@ trait Tables {
     val tweetId: Rep[Long] = column[Long]("TWEET_ID")
     /** Database column REGISTER_DATETIME SqlType(DATETIME) */
     val registerDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("REGISTER_DATETIME")
-    /** Database column UPDATE_DATETIME SqlType(DATETIME) */
-    val updateDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("UPDATE_DATETIME")
-    /** Database column VERSION_NO SqlType(BIGINT) */
-    val versionNo: Rep[Long] = column[Long]("VERSION_NO")
 
     /** Foreign key referencing Account (database name FK_ACCOUNT_TWEET_ACCOUNT) */
     lazy val accountFk = foreignKey("FK_ACCOUNT_TWEET_ACCOUNT", accountId, Account)(r => r.accountId, onUpdate=ForeignKeyAction.NoAction, onDelete=ForeignKeyAction.NoAction)
@@ -208,6 +196,9 @@ trait Tables {
     val updateDatetime: Rep[java.sql.Timestamp] = column[java.sql.Timestamp]("UPDATE_DATETIME")
     /** Database column VERSION_NO SqlType(BIGINT) */
     val versionNo: Rep[Long] = column[Long]("VERSION_NO")
+
+    /** Index over (registerDatetime) (database name IX_TWEET_REGISTER_DATETIME) */
+    val index1 = index("IX_TWEET_REGISTER_DATETIME", registerDatetime)
   }
   /** Collection-like TableQuery object for table Tweet */
   lazy val Tweet = new TableQuery(tag => new Tweet(tag))

--- a/app/repositories/TweetRepositoryJDBC.scala
+++ b/app/repositories/TweetRepositoryJDBC.scala
@@ -79,9 +79,7 @@ class TweetRepositoryJDBC {
           accountTweetId = Consts.DefaultId,
           accountId = aid,
           tweetId = tweet,
-          registerDatetime = Timestamp.valueOf(LocalDateTime.now),
-          updateDatetime = Timestamp.valueOf(LocalDateTime.now),
-          versionNo = Consts.DefaultVersionNo)
+          registerDatetime = Timestamp.valueOf(LocalDateTime.now)
       }
     } yield (tweet, accountTweet)).transactionally
   }

--- a/app/repositories/TweetRepositoryJDBC.scala
+++ b/app/repositories/TweetRepositoryJDBC.scala
@@ -65,7 +65,7 @@ class TweetRepositoryJDBC {
 
   def create(form: TweetCommand): DBIO[(Long, Option[Int])] = {
     (for {
-      a <- Tweet returning Tweet.map(_.tweetId) += TweetRow(
+      tweet <- Tweet returning Tweet.map(_.tweetId) += TweetRow(
         tweetId = 0L,
         // TODO(yuito) ログイン中のメンバーのAccountIdしかおくれないようにする
         tweetText = form.tweetText,
@@ -73,16 +73,16 @@ class TweetRepositoryJDBC {
         updateDatetime = Timestamp.valueOf(LocalDateTime.now),
         versionNo = 0L
       )
-      b <- AccountTweet ++= form.accountIds.get.map { aid =>
+      accountTweet <- AccountTweet ++= form.accountIds.get.map { aid =>
         AccountTweetRow(
           accountTweetId = 0L,
           accountId = aid,
-          tweetId = a,
+          tweetId = tweet,
           registerDatetime = Timestamp.valueOf(LocalDateTime.now),
           updateDatetime = Timestamp.valueOf(LocalDateTime.now),
           versionNo = 0L)
       }
-    } yield (a, b)).transactionally
+    } yield (tweet, accountTweet)).transactionally
   }
 
   def update(tweetId: Long, form: TweetCommand): DBIO[Int] = {

--- a/app/repositories/TweetRepositoryJDBC.scala
+++ b/app/repositories/TweetRepositoryJDBC.scala
@@ -9,6 +9,7 @@ import models.Tables.{Account, AccountTweet, Tweet}
 import scala.concurrent.ExecutionContext.Implicits.global
 import slick.driver.MySQLDriver.api._
 import models.Tables.{AccountTweetRow, TweetRow}
+import utils.Consts
 
 /**
   * TWEETテーブルに対するクエリを生成しActionを返すクラス
@@ -66,21 +67,21 @@ class TweetRepositoryJDBC {
   def create(form: TweetCommand): DBIO[(Long, Option[Int])] = {
     (for {
       tweet <- Tweet returning Tweet.map(_.tweetId) += TweetRow(
-        tweetId = 0L,
+        tweetId = Consts.DefaultId,
         // TODO(yuito) ログイン中のメンバーのAccountIdしかおくれないようにする
         tweetText = form.tweetText,
         registerDatetime = Timestamp.valueOf(LocalDateTime.now),
         updateDatetime = Timestamp.valueOf(LocalDateTime.now),
-        versionNo = 0L
+        versionNo = Consts.DefaultVersionNo
       )
       accountTweet <- AccountTweet ++= form.accountIds.get.map { aid =>
         AccountTweetRow(
-          accountTweetId = 0L,
+          accountTweetId = Consts.DefaultId,
           accountId = aid,
           tweetId = tweet,
           registerDatetime = Timestamp.valueOf(LocalDateTime.now),
           updateDatetime = Timestamp.valueOf(LocalDateTime.now),
-          versionNo = 0L)
+          versionNo = Consts.DefaultVersionNo)
       }
     } yield (tweet, accountTweet)).transactionally
   }

--- a/app/repositories/TweetRepositoryJDBC.scala
+++ b/app/repositories/TweetRepositoryJDBC.scala
@@ -3,12 +3,13 @@ package repositories
 import java.sql.Timestamp
 import java.time.LocalDateTime
 
-import formats.{TweetCommand, TweetView}
-import models.Tables.{Member, Tweet}
+import formats.{AccountView, TweetCommand, TweetView}
+import models.Tables.{Account, AccountTweet, Tweet}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import slick.driver.MySQLDriver.api._
 import models.Tables.TweetRow
+import play.api.Logger
 
 /**
   * TWEETテーブルに対するクエリを生成しActionを返すクラス
@@ -17,36 +18,51 @@ import models.Tables.TweetRow
   */
 class TweetRepositoryJDBC {
 
-  def listWithMember(): DBIO[Seq[TweetView]] = {
+  def list(): DBIO[Seq[TweetView]] = {
     Tweet
-      .join(Member).on { case (t, m) => t.memberId === m.memberId }
-      .sortBy { case (t, _) =>
+      .join(
+        AccountTweet.join(Account).on {
+          case (at, a) => at.accountId === a.accountId
+        }
+      ).on { case (t, (at, a)) => t.tweetId === at.tweetId }
+      .sortBy { case (t, (_, _)) =>
         t.registerDatetime.desc
       }
       .result
-      .map(_.map {
-        case (t, m) =>
-          TweetView.from(t, m)
+      .map(_.groupBy { case (t, (_, _)) =>
+        Logger.logger.debug(t.tweetId.toString)
+        t.tweetId
       })
-    // TODO(yuitoe)自分がフォローしているユーザーを含める
+      .map(_.map { case (key, rows) =>
+        Logger.logger.debug(key.toString)
+        val tweet = rows.map(_._1).head
+//        Logger.logger.debug(tweet.tweetId.toString)
+        val accounts = rows.map(_._2).map(_._2).map(AccountView.from)
+        TweetView.from(tweet, accounts)
+      }.toSeq)
   }
+
+  // TODO(yuitoe)自分がフォローしているユーザーを含める
 
   def find(tweetId: Long): DBIO[Option[TweetView]] = {
     Tweet
-      .join(Member).on { case (t, m) => t.memberId === m.memberId }
-      .filter { case (t, _) => t.tweetId === tweetId }
+      .join(
+        AccountTweet.join(Account).on {
+          case (at, a) => at.accountId === a.accountId
+        }
+      ).on { case (t, (at, a)) => t.tweetId === at.tweetId }
       .result
-      .headOption
-      .map(_.map {
-        case (t, m) =>
-          TweetView.from(t, m)
-      })
+      .map(_.groupBy { case (t, (_, _)) => t.tweetId })
+      .map(_.map { case (_, rows) =>
+        val tweet = rows.map(_._1).head
+        val accounts = rows.map(_._2).map(_._2).map(AccountView.from)
+        TweetView.from(tweet, accounts)
+      }.headOption)
   }
 
   def create(form: TweetCommand): DBIO[Int] = {
     Tweet += TweetRow(
       tweetId = 0L,
-      memberId = 1L,
       // TODO(yuito) ログイン中のメンバーのIDを取得する
       tweetText = form.tweetText,
       registerDatetime = Timestamp.valueOf(LocalDateTime.now),

--- a/app/repositories/TweetRepositoryJDBC.scala
+++ b/app/repositories/TweetRepositoryJDBC.scala
@@ -63,7 +63,7 @@ class TweetRepositoryJDBC {
   }
 
   def create(form: TweetCommand): DBIO[(Long, Option[Int])] = {
-    val transactionally = (for {
+    (for {
       a <- Tweet returning Tweet.map(_.tweetId) += TweetRow(
         tweetId = 0L,
         // TODO(yuito) ログイン中のメンバーのAccountIdしかおくれないようにする
@@ -82,7 +82,6 @@ class TweetRepositoryJDBC {
           versionNo = 0L)
       }
     } yield (a, b)).transactionally
-    transactionally
   }
 
   def update(tweetId: Long, form: TweetCommand): DBIO[Int] = {

--- a/app/repositories/TweetRepositoryJDBC.scala
+++ b/app/repositories/TweetRepositoryJDBC.scala
@@ -92,14 +92,13 @@ class TweetRepositoryJDBC {
       .update(form.tweetText, Timestamp.valueOf(LocalDateTime.now))
   }
 
-  def delete(tweetId: Long): DBIO[(Int, Int)] = {
+  def delete(tweetId: Long): DBIO[(Int, Int)] =
     (for {
-      tweet <- Tweet
-        .filter(_.tweetId === tweetId)
-        .delete
       accountTweet <- AccountTweet
         .filter(_.tweetId === tweetId)
         .delete
-    } yield (tweet, accountTweet)).transactionally
-  }
+      tweet <- Tweet
+        .filter(_.tweetId === tweetId)
+        .delete
+    } yield (accountTweet, tweet)).transactionally
 }

--- a/app/repositories/TweetRepositoryJDBC.scala
+++ b/app/repositories/TweetRepositoryJDBC.scala
@@ -45,6 +45,7 @@ class TweetRepositoryJDBC {
           }.toSeq)
       }
   }
+
   // TODO(yuito)自分がフォローしているユーザーを含める
 
   def find(tweetId: Long): DBIO[Option[TweetView]] = {
@@ -91,9 +92,14 @@ class TweetRepositoryJDBC {
       .update(form.tweetText, Timestamp.valueOf(LocalDateTime.now))
   }
 
-  def delete(tweetId: Long): DBIO[Int] = {
-    Tweet
-      .filter(_.tweetId === tweetId)
-      .delete
+  def delete(tweetId: Long): DBIO[(Int, Int)] = {
+    (for {
+      tweet <- Tweet
+        .filter(_.tweetId === tweetId)
+        .delete
+      accountTweet <- AccountTweet
+        .filter(_.tweetId === tweetId)
+        .delete
+    } yield (tweet, accountTweet)).transactionally
   }
 }

--- a/app/repositories/TweetRepositoryJDBC.scala
+++ b/app/repositories/TweetRepositoryJDBC.scala
@@ -22,7 +22,6 @@ class TweetRepositoryJDBC {
     val subAccountTweet = AccountTweet.join(Account).on {
       case (at, a) => at.accountId === a.accountId
     }
-
     Tweet
       .join(subAccountTweet).on { case (t, (at, _)) => t.tweetId === at.tweetId }
       .sortBy { case (t, (_, _)) =>
@@ -80,6 +79,7 @@ class TweetRepositoryJDBC {
           accountId = aid,
           tweetId = tweet,
           registerDatetime = Timestamp.valueOf(LocalDateTime.now)
+        )
       }
     } yield (tweet, accountTweet)).transactionally
   }
@@ -91,7 +91,7 @@ class TweetRepositoryJDBC {
       .update(form.tweetText, Timestamp.valueOf(LocalDateTime.now))
   }
 
-  def delete(tweetId: Long): DBIO[(Int, Int)] =
+  def delete(tweetId: Long): DBIO[(Int, Int)] = {
     (for {
       accountTweet <- AccountTweet
         .filter(_.tweetId === tweetId)
@@ -100,4 +100,5 @@ class TweetRepositoryJDBC {
         .filter(_.tweetId === tweetId)
         .delete
     } yield (accountTweet, tweet)).transactionally
+  }
 }

--- a/app/repositories/TweetRepositoryJDBC.scala
+++ b/app/repositories/TweetRepositoryJDBC.scala
@@ -72,7 +72,7 @@ class TweetRepositoryJDBC {
         updateDatetime = Timestamp.valueOf(LocalDateTime.now),
         versionNo = 0L
       )
-      b <- AccountTweet ++= form.accountIds.map { aid =>
+      b <- AccountTweet ++= form.accountIds.get.map { aid =>
         AccountTweetRow(
           accountTweetId = 0L,
           accountId = aid,

--- a/app/services/TweetService.scala
+++ b/app/services/TweetService.scala
@@ -32,7 +32,7 @@ class TweetService @Inject()(val tweetJdbc: TweetRepositoryJDBC, val dbConfigPro
     db.run(tweetJdbc.update(tweetId, form))
   }
 
-  def delete(tweetId: Long): Future[Int] = {
+  def delete(tweetId: Long): Future[(Int, Int)] = {
     db.run(tweetJdbc.delete(tweetId))
   }
 }

--- a/app/services/TweetService.scala
+++ b/app/services/TweetService.scala
@@ -24,7 +24,7 @@ class TweetService @Inject()(val tweetJdbc: TweetRepositoryJDBC, val dbConfigPro
     db.run(tweetJdbc.find(tweetId: Long))
   }
 
-  def create(form: TweetCommand): Future[Int] = {
+  def create(form: TweetCommand): Future[(Long, Option[Int])] = {
     db.run(tweetJdbc.create(form))
   }
 

--- a/app/services/TweetService.scala
+++ b/app/services/TweetService.scala
@@ -17,7 +17,7 @@ import slick.driver.JdbcProfile
 class TweetService @Inject()(val tweetJdbc: TweetRepositoryJDBC, val dbConfigProvider: DatabaseConfigProvider) extends HasDatabaseConfigProvider[JdbcProfile] {
 
   def list(): Future[Seq[TweetView]] = {
-    db.run(tweetJdbc.listWithMember())
+    db.run(tweetJdbc.list())
   }
 
   def find(tweetId: Long): Future[Option[TweetView]] = {

--- a/app/utils/Consts.scala
+++ b/app/utils/Consts.scala
@@ -1,6 +1,8 @@
 package utils
 
 /**
+  * アプリ上で使用する定数を管理するオブジェクト
+  *
   * @author yuito.sato
   */
 object Consts {

--- a/app/utils/Consts.scala
+++ b/app/utils/Consts.scala
@@ -1,0 +1,10 @@
+package utils
+
+/**
+  * @author yuito.sato
+  */
+object Consts {
+
+  val DefaultId = 0L
+  val DefaultVersionNo = 0L
+}

--- a/yuitterER.erm
+++ b/yuitterER.erm
@@ -169,6 +169,13 @@
 					<length>200</length>
 					<description>アカウントのアバター</description>
 				</normal_column>
+				<normal_column>
+					<physical_name>BACKGROUND_IMAGE</physical_name>
+					<logical_name>背景画像</logical_name>
+					<type>varchar(n)</type>
+					<length>200</length>
+					<description>プロフィール画面の背景画像&#x0A;</description>
+				</normal_column>
 				<column_group>COMMON_COLUMNS</column_group>
 			</columns>
 			<indexes>

--- a/yuitterER.erm
+++ b/yuitterER.erm
@@ -106,15 +106,312 @@
 	</tablespace_set>
 	<diagram_walkers>
 		<table>
+			<physical_name>ACCOUNT</physical_name>
+			<logical_name>アカウント</logical_name>
+			<description></description>
+			<height>162</height>
+			<width>240</width>
+			<font_name>.Helvetica Neue DeskInterface</font_name>
+			<font_size>9</font_size>
+			<x>780</x>
+			<y>389</y>
+			<color>
+				<r>128</r>
+				<g>128</g>
+				<b>192</b>
+			</color>
+			<connections>
+				<relationship>
+					<name>FK_ACCOUNT_MEMBER</name>
+					<source>table.MEMBER</source>
+					<target>table.ACCOUNT</target>
+					<fk_columns>
+						<fk_column>
+							<fk_column_name>MEMBER_ID</fk_column_name>
+						</fk_column>
+					</fk_columns>
+					<parent_cardinality>1</parent_cardinality>
+					<child_cardinality>0..n</child_cardinality>
+					<reference_for_pk>true</reference_for_pk>
+					<on_delete_action>RESTRICT</on_delete_action>
+					<on_update_action>RESTRICT</on_update_action>
+				</relationship>
+			</connections>
+			<columns>
+				<normal_column>
+					<physical_name>ACCOUNT_ID</physical_name>
+					<logical_name>アカウントID</logical_name>
+					<type>bigint</type>
+					<description>登録アカウントのID。MEMBERは複数のACCOUNTを保持することができる。</description>
+					<not_null>true</not_null>
+					<primary_key>true</primary_key>
+					<auto_increment>true</auto_increment>
+				</normal_column>
+				<normal_column>
+					<physical_name>MEMBER_ID</physical_name>
+					<referred_column>table.MEMBER.MEMBER_ID</referred_column>
+					<relationship>FK_ACCOUNT_MEMBER</relationship>
+					<description>登録会員のID&#x0A;</description>
+					<not_null>true</not_null>
+				</normal_column>
+				<normal_column>
+					<physical_name>AccountName</physical_name>
+					<logical_name>アカウント名</logical_name>
+					<type>varchar(n)</type>
+					<length>50</length>
+					<description>登録アカウントの名前</description>
+					<not_null>true</not_null>
+				</normal_column>
+				<normal_column>
+					<physical_name>AVATAR</physical_name>
+					<logical_name>アバター</logical_name>
+					<type>varchar(n)</type>
+					<length>200</length>
+					<description>アカウントのアバター</description>
+				</normal_column>
+				<column_group>COMMON_COLUMNS</column_group>
+			</columns>
+			<indexes>
+				<index>
+					<name>IX_ACCOUNT_ACCOUNT_ID</name>
+					<type>BTREE</type>
+					<non_unique>true</non_unique>
+					<columns>
+						<column>
+							<column_id>table.ACCOUNT.ACCOUNT_ID</column_id>
+						</column>
+					</columns>
+				</index>
+				<index>
+					<name>IX_ACCOUNT_MEMBER_ID</name>
+					<type>BTREE</type>
+					<non_unique>true</non_unique>
+					<columns>
+						<column>
+							<column_id>table.ACCOUNT.MEMBER_ID</column_id>
+						</column>
+					</columns>
+				</index>
+			</indexes>
+			<compound_unique_key_list>
+			</compound_unique_key_list>
+			<table_properties>
+			</table_properties>
+		</table>
+		<table>
+			<physical_name>ACCOUNT_FOLLOWING</physical_name>
+			<logical_name>アカウントフォローイング</logical_name>
+			<description></description>
+			<height>192</height>
+			<width>367</width>
+			<font_name>.Helvetica Neue DeskInterface</font_name>
+			<font_size>9</font_size>
+			<x>315</x>
+			<y>387</y>
+			<color>
+				<r>128</r>
+				<g>128</g>
+				<b>192</b>
+			</color>
+			<connections>
+				<relationship>
+					<name>FK_FOLLOWER_ACCOUNT</name>
+					<source>table.ACCOUNT</source>
+					<target>table.ACCOUNT_FOLLOWING</target>
+					<fk_columns>
+						<fk_column>
+							<fk_column_name>FOLLOWER_ID</fk_column_name>
+						</fk_column>
+					</fk_columns>
+					<parent_cardinality>1</parent_cardinality>
+					<child_cardinality>0..n</child_cardinality>
+					<reference_for_pk>true</reference_for_pk>
+					<on_delete_action>RESTRICT</on_delete_action>
+					<on_update_action>RESTRICT</on_update_action>
+				</relationship>
+				<relationship>
+					<name>FK_ACCOUNT_FOLLOWEE_ACCOUNT</name>
+					<source>table.ACCOUNT</source>
+					<target>table.ACCOUNT_FOLLOWING</target>
+					<fk_columns>
+						<fk_column>
+							<fk_column_name>FOLLOWEE_ID</fk_column_name>
+						</fk_column>
+					</fk_columns>
+					<parent_cardinality>1</parent_cardinality>
+					<child_cardinality>0..n</child_cardinality>
+					<reference_for_pk>true</reference_for_pk>
+					<on_delete_action>RESTRICT</on_delete_action>
+					<on_update_action>RESTRICT</on_update_action>
+					<target_xp>100</target_xp>
+					<target_yp>67</target_yp>
+				</relationship>
+			</connections>
+			<columns>
+				<normal_column>
+					<physical_name>MEMBER_FOLLOWING_ID</physical_name>
+					<logical_name>会員フォローイングID</logical_name>
+					<type>bigint</type>
+					<description>会員のフォロワー、フォロイーの組み合わせレコードのID</description>
+					<not_null>true</not_null>
+					<primary_key>true</primary_key>
+					<auto_increment>true</auto_increment>
+				</normal_column>
+				<normal_column>
+					<physical_name>FOLLOWER_ID</physical_name>
+					<logical_name>フォロワーID</logical_name>
+					<referred_column>table.ACCOUNT.ACCOUNT_ID</referred_column>
+					<relationship>FK_FOLLOWER_ACCOUNT</relationship>
+					<description>フォローしている人のID</description>
+					<not_null>true</not_null>
+				</normal_column>
+				<normal_column>
+					<physical_name>FOLLOWEE_ID</physical_name>
+					<logical_name>フォロイーID</logical_name>
+					<referred_column>table.ACCOUNT.ACCOUNT_ID</referred_column>
+					<relationship>FK_ACCOUNT_FOLLOWEE_ACCOUNT</relationship>
+					<description>フォローされている人のID</description>
+					<not_null>true</not_null>
+				</normal_column>
+				<column_group>COMMON_COLUMNS</column_group>
+			</columns>
+			<indexes>
+				<index>
+					<name>IX_ACCOUNT_FOLLOWING_FOLLOWER_ID</name>
+					<type>BTREE</type>
+					<non_unique>true</non_unique>
+					<columns>
+						<column>
+							<column_id>table.ACCOUNT_FOLLOWING.FOLLOWER_ID</column_id>
+						</column>
+					</columns>
+				</index>
+				<index>
+					<name>IX_ACCOUNT_FOLLOWING_FOLLOWEE</name>
+					<type>BTREE</type>
+					<non_unique>true</non_unique>
+					<columns>
+						<column>
+							<column_id>table.ACCOUNT_FOLLOWING.FOLLOWEE_ID</column_id>
+						</column>
+					</columns>
+				</index>
+			</indexes>
+			<compound_unique_key_list>
+			</compound_unique_key_list>
+			<table_properties>
+			</table_properties>
+		</table>
+		<table>
+			<physical_name>ACCOUNT_TWEET</physical_name>
+			<logical_name>アカウントツイート</logical_name>
+			<description></description>
+			<height>225</height>
+			<width>293</width>
+			<font_name>.Helvetica Neue DeskInterface</font_name>
+			<font_size>9</font_size>
+			<x>762</x>
+			<y>672</y>
+			<color>
+				<r>128</r>
+				<g>128</g>
+				<b>192</b>
+			</color>
+			<connections>
+				<relationship>
+					<name>FK_ACCOUNT_TWEET_Account</name>
+					<source>table.ACCOUNT</source>
+					<target>table.ACCOUNT_TWEET</target>
+					<fk_columns>
+						<fk_column>
+							<fk_column_name>ACCOUNT_ID</fk_column_name>
+						</fk_column>
+					</fk_columns>
+					<parent_cardinality>1</parent_cardinality>
+					<child_cardinality>0..n</child_cardinality>
+					<reference_for_pk>true</reference_for_pk>
+					<on_delete_action>RESTRICT</on_delete_action>
+					<on_update_action>RESTRICT</on_update_action>
+				</relationship>
+				<relationship>
+					<name>FK_ACCOUNT_TWEET_TWEET</name>
+					<source>table.TWEET</source>
+					<target>table.ACCOUNT_TWEET</target>
+					<fk_columns>
+						<fk_column>
+							<fk_column_name>TWEET_ID</fk_column_name>
+						</fk_column>
+					</fk_columns>
+					<parent_cardinality>1</parent_cardinality>
+					<child_cardinality>0..n</child_cardinality>
+					<reference_for_pk>true</reference_for_pk>
+					<on_delete_action>RESTRICT</on_delete_action>
+					<on_update_action>RESTRICT</on_update_action>
+				</relationship>
+			</connections>
+			<columns>
+				<normal_column>
+					<physical_name>ACCOUNT_TWEET_ID</physical_name>
+					<logical_name>アカウントツイートID</logical_name>
+					<type>bigint</type>
+					<description>アカウントツイートID</description>
+					<not_null>true</not_null>
+					<primary_key>true</primary_key>
+					<auto_increment>true</auto_increment>
+				</normal_column>
+				<normal_column>
+					<physical_name>ACCOUNT_ID</physical_name>
+					<referred_column>table.ACCOUNT.ACCOUNT_ID</referred_column>
+					<relationship>FK_ACCOUNT_TWEET_Account</relationship>
+					<description>登録アカウントのID</description>
+					<not_null>true</not_null>
+				</normal_column>
+				<normal_column>
+					<physical_name>TWEET_ID</physical_name>
+					<referred_column>table.TWEET.TWEET_ID</referred_column>
+					<relationship>FK_ACCOUNT_TWEET_TWEET</relationship>
+					<description>登録ツイートのID</description>
+					<not_null>true</not_null>
+				</normal_column>
+				<column_group>COMMON_COLUMNS</column_group>
+			</columns>
+			<indexes>
+				<index>
+					<name>IX_ACCOUNT_TWEET_ACCOUNT_ID</name>
+					<type>BTREE</type>
+					<non_unique>true</non_unique>
+					<columns>
+						<column>
+							<column_id>table.ACCOUNT_TWEET.ACCOUNT_ID</column_id>
+						</column>
+					</columns>
+				</index>
+				<index>
+					<name>IX_ACCOUNT_TWEET_TWEET_ID</name>
+					<type>BTREE</type>
+					<non_unique>true</non_unique>
+					<columns>
+						<column>
+							<column_id>table.ACCOUNT_TWEET.TWEET_ID</column_id>
+						</column>
+					</columns>
+				</index>
+			</indexes>
+			<compound_unique_key_list>
+			</compound_unique_key_list>
+			<table_properties>
+			</table_properties>
+		</table>
+		<table>
 			<physical_name>MEMBER</physical_name>
 			<logical_name>会員</logical_name>
 			<description>会員情報を保持するテーブル</description>
-			<height>228</height>
+			<height>179</height>
 			<width>284</width>
 			<font_name>.Helvetica Neue DeskInterface</font_name>
 			<font_size>9</font_size>
-			<x>338</x>
-			<y>53</y>
+			<x>756</x>
+			<y>152</y>
 			<color>
 				<r>128</r>
 				<g>128</g>
@@ -133,23 +430,6 @@
 					<auto_increment>true</auto_increment>
 				</normal_column>
 				<normal_column>
-					<physical_name>MEMBER_NAME</physical_name>
-					<logical_name>会員名称</logical_name>
-					<type>varchar(n)</type>
-					<length>50</length>
-					<description>会員の名称。ニックネームでも可。</description>
-					<not_null>true</not_null>
-				</normal_column>
-				<normal_column>
-					<physical_name>MEMBER_ACCOUNT</physical_name>
-					<logical_name>会員アカウント</logical_name>
-					<type>varchar(n)</type>
-					<length>50</length>
-					<description>会員レコードの識別子。</description>
-					<not_null>true</not_null>
-					<unique_key>true</unique_key>
-				</normal_column>
-				<normal_column>
 					<physical_name>EMAIL_ADDRESS</physical_name>
 					<logical_name>Emailアドレス</logical_name>
 					<type>varchar(n)</type>
@@ -161,142 +441,21 @@
 				<normal_column>
 					<physical_name>PASSWORD</physical_name>
 					<logical_name>パスワード</logical_name>
-					<type>varchar(n)</type>
-					<length>200</length>
-					<description>ログインの際に必要なパスワード。ハッシュ化されてDBに保存される</description>
-					<not_null>true</not_null>
-				</normal_column>
-				<normal_column>
-					<physical_name>MEMBER_AVATAR</physical_name>
-					<logical_name>会員アバター</logical_name>
-					<type>varchar(n)</type>
-					<length>200</length>
-					<description>会員のプロフィール画像</description>
-				</normal_column>
-				<column_group>COMMON_COLUMNS</column_group>
-			</columns>
-			<indexes>
-				<index>
-					<name>IX_MEMBER_MEMBER_NAME</name>
-					<type>BTREE</type>
-					<description>会員名での検索のためのインデックス</description>
-					<non_unique>true</non_unique>
-					<columns>
-						<column>
-							<column_id>table.MEMBER.MEMBER_NAME</column_id>
-						</column>
-					</columns>
-				</index>
-				<index>
-					<name>IX_MEMBER_MEMBER_ACCOUNT</name>
-					<type>BTREE</type>
-					<description>メンバーアカウントで検索するためのインデックス</description>
-					<non_unique>true</non_unique>
-					<columns>
-						<column>
-							<column_id>table.MEMBER.MEMBER_ACCOUNT</column_id>
-						</column>
-					</columns>
-				</index>
-			</indexes>
-			<compound_unique_key_list>
-			</compound_unique_key_list>
-			<table_properties>
-			</table_properties>
-		</table>
-		<table>
-			<physical_name>MEMBER_FOLLOWING</physical_name>
-			<logical_name>会員フォローイング</logical_name>
-			<description></description>
-			<height>192</height>
-			<width>321</width>
-			<font_name>.Helvetica Neue DeskInterface</font_name>
-			<font_size>9</font_size>
-			<x>51</x>
-			<y>383</y>
-			<color>
-				<r>128</r>
-				<g>128</g>
-				<b>192</b>
-			</color>
-			<connections>
-				<relationship>
-					<name>FK_MEMBER_FOLLOWER</name>
-					<source>table.MEMBER</source>
-					<target>table.MEMBER_FOLLOWING</target>
-					<fk_columns>
-						<fk_column>
-							<fk_column_name>FOLLOWER_ID</fk_column_name>
-						</fk_column>
-					</fk_columns>
-					<parent_cardinality>1</parent_cardinality>
-					<child_cardinality>0..n</child_cardinality>
-					<reference_for_pk>true</reference_for_pk>
-					<on_delete_action>RESTRICT</on_delete_action>
-					<on_update_action>RESTRICT</on_update_action>
-				</relationship>
-				<relationship>
-					<name>FK_MEMBER_FOLLOWEE</name>
-					<source>table.MEMBER</source>
-					<target>table.MEMBER_FOLLOWING</target>
-					<fk_columns>
-						<fk_column>
-							<fk_column_name>FOLLOWEE_ID</fk_column_name>
-						</fk_column>
-					</fk_columns>
-					<parent_cardinality>1</parent_cardinality>
-					<child_cardinality>0..n</child_cardinality>
-					<reference_for_pk>true</reference_for_pk>
-					<on_delete_action>RESTRICT</on_delete_action>
-					<on_update_action>RESTRICT</on_update_action>
-				</relationship>
-			</connections>
-			<columns>
-				<normal_column>
-					<physical_name>MEMBER_FOLLOWING_ID</physical_name>
-					<logical_name>会員フォローイングID</logical_name>
-					<type>bigint</type>
-					<description>会員のフォロワー、フォロイーの組み合わせレコードのID</description>
-					<not_null>true</not_null>
-					<primary_key>true</primary_key>
-					<auto_increment>true</auto_increment>
-				</normal_column>
-				<normal_column>
-					<physical_name>FOLLOWER_ID</physical_name>
-					<logical_name>フォロワーID</logical_name>
-					<referred_column>table.MEMBER.MEMBER_ID</referred_column>
-					<relationship>FK_MEMBER_FOLLOWER</relationship>
-					<description>フォローをしている会員のID</description>
-					<not_null>true</not_null>
-				</normal_column>
-				<normal_column>
-					<physical_name>FOLLOWEE_ID</physical_name>
-					<logical_name>フォロイーID</logical_name>
-					<referred_column>table.MEMBER.MEMBER_ID</referred_column>
-					<relationship>FK_MEMBER_FOLLOWEE</relationship>
-					<description>フォローされる会員のID</description>
+					<type>character(n)</type>
+					<length>60</length>
+					<description>ログインの際に必要なパスワード。ハッシュ化されてDBに保存される&#x0A;BCryptによるハッシュ化を行う</description>
 					<not_null>true</not_null>
 				</normal_column>
 				<column_group>COMMON_COLUMNS</column_group>
 			</columns>
 			<indexes>
 				<index>
-					<name>IX_MEMBER_FOLLOWING_FOLLOWER_ID</name>
+					<name>IX_MEMBER_MEMBER_ID</name>
 					<type>BTREE</type>
 					<non_unique>true</non_unique>
 					<columns>
 						<column>
-							<column_id>table.MEMBER_FOLLOWING.FOLLOWER_ID</column_id>
-						</column>
-					</columns>
-				</index>
-				<index>
-					<name>IX_MEMBER_FOLLOWING_FOLLOWEE_ID</name>
-					<type>BTREE</type>
-					<non_unique>true</non_unique>
-					<columns>
-						<column>
-							<column_id>table.MEMBER_FOLLOWING.FOLLOWEE_ID</column_id>
+							<column_id>table.MEMBER.MEMBER_ID</column_id>
 						</column>
 					</columns>
 				</index>
@@ -310,33 +469,18 @@
 			<physical_name>TWEET</physical_name>
 			<logical_name>ツイート</logical_name>
 			<description></description>
-			<height>180</height>
+			<height>192</height>
 			<width>231</width>
 			<font_name>.Helvetica Neue DeskInterface</font_name>
 			<font_size>9</font_size>
-			<x>10</x>
-			<y>125</y>
+			<x>1097</x>
+			<y>398</y>
 			<color>
 				<r>128</r>
 				<g>128</g>
 				<b>192</b>
 			</color>
 			<connections>
-				<relationship>
-					<name>FK_TWEET_MEMBER</name>
-					<source>table.MEMBER</source>
-					<target>table.TWEET</target>
-					<fk_columns>
-						<fk_column>
-							<fk_column_name>MEMBER_ID</fk_column_name>
-						</fk_column>
-					</fk_columns>
-					<parent_cardinality>1</parent_cardinality>
-					<child_cardinality>0..n</child_cardinality>
-					<reference_for_pk>true</reference_for_pk>
-					<on_delete_action>RESTRICT</on_delete_action>
-					<on_update_action>RESTRICT</on_update_action>
-				</relationship>
 			</connections>
 			<columns>
 				<normal_column>
@@ -347,12 +491,6 @@
 					<not_null>true</not_null>
 					<primary_key>true</primary_key>
 					<auto_increment>true</auto_increment>
-				</normal_column>
-				<normal_column>
-					<physical_name>MEMBER_ID</physical_name>
-					<referred_column>table.MEMBER.MEMBER_ID</referred_column>
-					<relationship>FK_TWEET_MEMBER</relationship>
-					<not_null>true</not_null>
 				</normal_column>
 				<normal_column>
 					<physical_name>TWEET_TEXT</physical_name>
@@ -366,22 +504,12 @@
 			</columns>
 			<indexes>
 				<index>
-					<name>IX_TWEET_MEMBER_ID</name>
+					<name>IX_TWEET_TWEET_ID</name>
 					<type>BTREE</type>
 					<non_unique>true</non_unique>
 					<columns>
 						<column>
-							<column_id>table.TWEET.MEMBER_ID</column_id>
-						</column>
-					</columns>
-				</index>
-				<index>
-					<name>IX_TWEET_TWEET_TEXT</name>
-					<type>BTREE</type>
-					<non_unique>true</non_unique>
-					<columns>
-						<column>
-							<column_id>table.TWEET.TWEET_TEXT</column_id>
+							<column_id>table.TWEET.TWEET_ID</column_id>
 						</column>
 					</columns>
 				</index>

--- a/yuitterER.erm
+++ b/yuitterER.erm
@@ -155,7 +155,7 @@
 					<not_null>true</not_null>
 				</normal_column>
 				<normal_column>
-					<physical_name>AccountName</physical_name>
+					<physical_name>ACCOUNT_NAME</physical_name>
 					<logical_name>アカウント名</logical_name>
 					<type>varchar(n)</type>
 					<length>50</length>

--- a/yuitterER.erm
+++ b/yuitterER.erm
@@ -109,12 +109,12 @@
 			<physical_name>ACCOUNT</physical_name>
 			<logical_name>アカウント</logical_name>
 			<description></description>
-			<height>162</height>
-			<width>240</width>
+			<height>228</height>
+			<width>257</width>
 			<font_name>.Helvetica Neue DeskInterface</font_name>
 			<font_size>9</font_size>
-			<x>780</x>
-			<y>389</y>
+			<x>530</x>
+			<y>368</y>
 			<color>
 				<r>128</r>
 				<g>128</g>
@@ -213,8 +213,8 @@
 			<width>367</width>
 			<font_name>.Helvetica Neue DeskInterface</font_name>
 			<font_size>9</font_size>
-			<x>315</x>
-			<y>387</y>
+			<x>64</x>
+			<y>398</y>
 			<color>
 				<r>128</r>
 				<g>128</g>
@@ -317,8 +317,8 @@
 			<width>293</width>
 			<font_name>.Helvetica Neue DeskInterface</font_name>
 			<font_size>9</font_size>
-			<x>762</x>
-			<y>672</y>
+			<x>650</x>
+			<y>671</y>
 			<color>
 				<r>128</r>
 				<g>128</g>
@@ -417,8 +417,8 @@
 			<width>284</width>
 			<font_name>.Helvetica Neue DeskInterface</font_name>
 			<font_size>9</font_size>
-			<x>756</x>
-			<y>152</y>
+			<x>529</x>
+			<y>122</y>
 			<color>
 				<r>128</r>
 				<g>128</g>
@@ -480,8 +480,8 @@
 			<width>231</width>
 			<font_name>.Helvetica Neue DeskInterface</font_name>
 			<font_size>9</font_size>
-			<x>1097</x>
-			<y>398</y>
+			<x>927</x>
+			<y>395</y>
 			<color>
 				<r>128</r>
 				<g>128</g>

--- a/yuitterER.erm
+++ b/yuitterER.erm
@@ -131,7 +131,7 @@
 						</fk_column>
 					</fk_columns>
 					<parent_cardinality>1</parent_cardinality>
-					<child_cardinality>0..n</child_cardinality>
+					<child_cardinality>1..n</child_cardinality>
 					<reference_for_pk>true</reference_for_pk>
 					<on_delete_action>RESTRICT</on_delete_action>
 					<on_update_action>RESTRICT</on_update_action>
@@ -280,7 +280,7 @@
 					<description>フォローされている人のID</description>
 					<not_null>true</not_null>
 				</normal_column>
-				<column_group>COMMON_COLUMNS</column_group>
+				<column_group>NON_UPDATED_COMMON_COLUMNS</column_group>
 			</columns>
 			<indexes>
 				<index>
@@ -350,7 +350,7 @@
 						</fk_column>
 					</fk_columns>
 					<parent_cardinality>1</parent_cardinality>
-					<child_cardinality>0..n</child_cardinality>
+					<child_cardinality>1..n</child_cardinality>
 					<reference_for_pk>true</reference_for_pk>
 					<on_delete_action>RESTRICT</on_delete_action>
 					<on_update_action>RESTRICT</on_update_action>
@@ -380,7 +380,7 @@
 					<description>登録ツイートのID</description>
 					<not_null>true</not_null>
 				</normal_column>
-				<column_group>COMMON_COLUMNS</column_group>
+				<column_group>NON_UPDATED_COMMON_COLUMNS</column_group>
 			</columns>
 			<indexes>
 				<index>
@@ -520,6 +520,16 @@
 						</column>
 					</columns>
 				</index>
+				<index>
+					<name>IX_TWEET_REGISTER_DATETIME</name>
+					<type>BTREE</type>
+					<non_unique>true</non_unique>
+					<columns>
+						<column>
+							<column_id>columnGroup.COMMON_COLUMNS.REGISTER_DATETIME</column_id>
+						</column>
+					</columns>
+				</index>
 			</indexes>
 			<compound_unique_key_list>
 			</compound_unique_key_list>
@@ -552,6 +562,17 @@
 					<logical_name>バージョン番号</logical_name>
 					<type>bigint</type>
 					<description>レコードのバージョンナンバー。排他制御をするためのカラム</description>
+					<not_null>true</not_null>
+				</normal_column>
+			</columns>
+		</column_group>
+		<column_group>
+			<column_group_name>NON_UPDATED_COMMON_COLUMNS</column_group_name>
+			<columns>
+				<normal_column>
+					<physical_name>REGISTER_DATETIME</physical_name>
+					<logical_name>登録日時</logical_name>
+					<type>datetime</type>
 					<not_null>true</not_null>
 				</normal_column>
 			</columns>


### PR DESCRIPTION
 概要
- DBの変更
    - ひとつのパスワードとアドレスで複数のアカウントを管理できるようにした。
    - ツイートは複数のアカウントに紐付けながら投稿することができる（全ての管理しているアカウントで同じツイートを一気に投稿することが可能）
    - この場合ツイートは複数作成されるのではなく複数のアカウントで一つのツイートを参照するようになる。ツイートとアカウントは多対多の関係になる。
- それに伴うTweetApiの変更
    - ツイートリスト検索を複数のアカウントを関連付けさせながら取得するようにした。
    - ツイートを追加する時に複数のアカウントに関連付けながら保存できるようにした。


![yuitterer](https://user-images.githubusercontent.com/27726063/27071115-96734152-5056-11e7-940e-6c4cedcac0fd.png)
