### PR TITLE
各種APIの調整

### DIFF
--- a/app/controllers/AccountController.scala
+++ b/app/controllers/AccountController.scala
@@ -106,8 +106,9 @@ class AccountController @Inject()(val authenticatedAction: AuthenticatedAction, 
         )
       },
       valid = { form =>
-        accountService.update(accountId, form).map { _ =>
-          Ok(Json.obj("result" -> "success"))
+        accountService.update(accountId, form).map {
+          case 0 => BadRequest(Json.obj("result" -> "failure", "error" -> "更新に失敗しました。"))
+          case _ => Ok(Json.obj("result" -> "success"))
         }
       }
     )
@@ -119,8 +120,9 @@ class AccountController @Inject()(val authenticatedAction: AuthenticatedAction, 
     * @return 処理の結果
     */
   def delete(accountId: Long): Action[AnyContent] = authenticatedAction.async { implicit rs =>
-    accountService.delete(accountId).map { _ =>
-      Ok(Json.obj("result" -> "success"))
+    accountService.delete(accountId).map {
+      case (0, 0) => BadRequest(Json.obj("result" -> "failure", "error" -> "削除に失敗しました。"))
+      case (at, a) => Ok(Json.obj("result" -> "success", "error" -> ("AccountTweet削除:" + at.toString + "件" + "Account削除:" + a.toString + "件")))
     }
   }
 }

--- a/app/controllers/TweetController.scala
+++ b/app/controllers/TweetController.scala
@@ -35,7 +35,7 @@ class TweetController @Inject()(val tweetService: TweetService, val authenticate
     * @param tweetId 検索するツイートのID
     * @return Action[AnyContent]
     */
-  def find(tweetId: Long): Action[AnyContent] = Action.async { implicit rs =>
+  def find(tweetId: Long): Action[AnyContent] = authenticatedAction.async { implicit rs =>
     tweetService.find(tweetId).map {
       case Some(tweet) => Ok(Json.toJson(tweet))
       case None => BadRequest(Json.obj("result" -> "failure"))
@@ -47,7 +47,7 @@ class TweetController @Inject()(val tweetService: TweetService, val authenticate
     *
     * @return Action[JsValue]
     */
-  def create: Action[JsValue] = Action.async(parse.json) { implicit rs =>
+  def create: Action[JsValue] = authenticatedAction.async(parse.json) { implicit rs =>
     rs.body.validate[TweetCommand].fold(
       invalid = { e =>
         Future.successful(
@@ -68,7 +68,7 @@ class TweetController @Inject()(val tweetService: TweetService, val authenticate
     * @param tweetId 更新するツイートのID
     * @return Action[JsValue]
     */
-  def update(tweetId: Long): Action[JsValue] = Action.async(parse.json) { implicit rs =>
+  def update(tweetId: Long): Action[JsValue] = authenticatedAction.async(parse.json) { implicit rs =>
     rs.body.validate[TweetCommand].fold(
       invalid = { e =>
         Future.successful(
@@ -89,7 +89,7 @@ class TweetController @Inject()(val tweetService: TweetService, val authenticate
     * @param tweetId 削除するツイートのID
     * @return
     */
-  def delete(tweetId: Long): Action[AnyContent] = Action.async { implicit rs =>
+  def delete(tweetId: Long): Action[AnyContent] = authenticatedAction.async { implicit rs =>
     tweetService.delete(tweetId).map { _ =>
       Ok(Json.obj("result" -> "success"));
     }

--- a/app/controllers/TweetController.scala
+++ b/app/controllers/TweetController.scala
@@ -1,11 +1,14 @@
 package controllers
 
 import javax.inject.Inject
+
 import formats.TweetCommand
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, Controller}
+import security.AuthenticatedAction
 import services.TweetService
+
 import scala.concurrent.Future
 
 /**
@@ -13,15 +16,15 @@ import scala.concurrent.Future
   *
   * @author yuito.sato
   */
-class TweetController @Inject()(val tweetService: TweetService) extends Controller {
+class TweetController @Inject()(val tweetService: TweetService, val authenticatedAction: AuthenticatedAction) extends Controller {
 
   /**
     * Tweetの一覧取得 GET /api/tweets
     *
     * @return Action[AnyContent]
     */
-  def list: Action[AnyContent] = Action.async { implicit rs =>
-    tweetService.list().map { tweets =>
+  def list(accountId: Long): Action[AnyContent] = authenticatedAction.async { implicit rs =>
+    tweetService.list(accountId).map { tweets =>
       Ok(Json.toJson(tweets))
     }
   }

--- a/app/controllers/TweetController.scala
+++ b/app/controllers/TweetController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import javax.inject.Inject
 
-import formats.TweetCommand
+import formats.{TweetCreateCommand, TweetUpdateCommand}
 import play.api.libs.concurrent.Execution.Implicits.defaultContext
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, Controller}
@@ -48,7 +48,7 @@ class TweetController @Inject()(val tweetService: TweetService, val authenticate
     * @return Action[JsValue]
     */
   def create: Action[JsValue] = authenticatedAction.async(parse.json) { implicit rs =>
-    rs.body.validate[TweetCommand].fold(
+    rs.body.validate[TweetCreateCommand].fold(
       invalid = { e =>
         Future.successful(
           BadRequest(Json.obj("result" -> "failure", "error" -> JsError.toJson(e)))
@@ -69,7 +69,7 @@ class TweetController @Inject()(val tweetService: TweetService, val authenticate
     * @return Action[JsValue]
     */
   def update(tweetId: Long): Action[JsValue] = authenticatedAction.async(parse.json) { implicit rs =>
-    rs.body.validate[TweetCommand].fold(
+    rs.body.validate[TweetUpdateCommand].fold(
       invalid = { e =>
         Future.successful(
           BadRequest(Json.obj("result" -> "failure", "error" -> JsError.toJson(e)))

--- a/app/formats/TweetCreateCommand.scala
+++ b/app/formats/TweetCreateCommand.scala
@@ -7,13 +7,12 @@ import play.api.libs.json.{Json, Reads}
   *
   * @author yuito.sato
   */
-case class TweetCommand(
+case class TweetCreateCommand(
   tweetText: String,
-  versionNo: Option[Long],
-  accountIds: Option[Seq[Long]]
+  accountIds: Seq[Long]
 )
 
-object TweetCommand {
+object TweetCreateCommand {
 
-  implicit val TweetCommandReads: Reads[TweetCommand] = Json.reads[TweetCommand]
+  implicit val TweetCommandReads: Reads[TweetCreateCommand] = Json.reads[TweetCreateCommand]
 }

--- a/app/formats/TweetCreateCommand.scala
+++ b/app/formats/TweetCreateCommand.scala
@@ -1,6 +1,9 @@
 package formats
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.Reads._
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads}
+import utils.Consts
 
 /**
   * Tweetテーブルに関するフォームのケースクラス
@@ -14,5 +17,8 @@ case class TweetCreateCommand(
 
 object TweetCreateCommand {
 
-  implicit val TweetCommandReads: Reads[TweetCreateCommand] = Json.reads[TweetCreateCommand]
+  implicit val TweetCommandReads: Reads[TweetCreateCommand] = (
+    (JsPath \ "tweetText").read[String](maxLength[String](Consts.TweetTextMaxLength)) and
+    (JsPath \ "accountIds").read[Seq[Long]]
+    ) (TweetCreateCommand.apply _)
 }

--- a/app/formats/TweetUpdateCommand.scala
+++ b/app/formats/TweetUpdateCommand.scala
@@ -1,6 +1,9 @@
 package formats
 
-import play.api.libs.json.{Json, Reads}
+import play.api.libs.json.Reads.maxLength
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{JsPath, Reads}
+import utils.Consts
 
 /**
   * Tweetテーブルに関するフォームのケースクラス
@@ -14,5 +17,8 @@ case class TweetUpdateCommand(
 
 object TweetUpdateCommand {
 
-  implicit val TweetCommandReads: Reads[TweetUpdateCommand] = Json.reads[TweetUpdateCommand]
+  implicit val TweetCommandReads: Reads[TweetUpdateCommand] = (
+    (JsPath \ "tweetText").read[String](maxLength[String](Consts.TweetTextMaxLength)) and
+    (JsPath \ "versionNo").read[Long]
+  ) (TweetUpdateCommand.apply _)
 }

--- a/app/formats/TweetUpdateCommand.scala
+++ b/app/formats/TweetUpdateCommand.scala
@@ -1,0 +1,18 @@
+package formats
+
+import play.api.libs.json.{Json, Reads}
+
+/**
+  * Tweetテーブルに関するフォームのケースクラス
+  *
+  * @author yuito.sato
+  */
+case class TweetUpdateCommand(
+  tweetText: String,
+  versionNo: Long
+)
+
+object TweetUpdateCommand {
+
+  implicit val TweetCommandReads: Reads[TweetUpdateCommand] = Json.reads[TweetUpdateCommand]
+}

--- a/app/models/Tables.scala
+++ b/app/models/Tables.scala
@@ -63,11 +63,11 @@ trait Tables {
   lazy val Account = new TableQuery(tag => new Account(tag))
 
   /** Entity class storing rows of table AccountFollowing
-   *  @param memberFollowingId Database column MEMBER_FOLLOWING_ID SqlType(BIGINT), AutoInc, PrimaryKey
+   *  @param accountFollowingId Database column ACCOUNT_FOLLOWING_ID SqlType(BIGINT), PrimaryKey
    *  @param followerId Database column FOLLOWER_ID SqlType(BIGINT)
    *  @param followeeId Database column FOLLOWEE_ID SqlType(BIGINT)
    *  @param registerDatetime Database column REGISTER_DATETIME SqlType(DATETIME) */
-  case class AccountFollowingRow(memberFollowingId: Long, followerId: Long, followeeId: Long, registerDatetime: java.sql.Timestamp)
+  case class AccountFollowingRow(accountFollowingId: Long, followerId: Long, followeeId: Long, registerDatetime: java.sql.Timestamp)
   /** GetResult implicit for fetching AccountFollowingRow objects using plain SQL queries */
   implicit def GetResultAccountFollowingRow(implicit e0: GR[Long], e1: GR[java.sql.Timestamp]): GR[AccountFollowingRow] = GR{
     prs => import prs._
@@ -75,12 +75,12 @@ trait Tables {
   }
   /** Table description of table ACCOUNT_FOLLOWING. Objects of this class serve as prototypes for rows in queries. */
   class AccountFollowing(_tableTag: Tag) extends Table[AccountFollowingRow](_tableTag, "ACCOUNT_FOLLOWING") {
-    def * = (memberFollowingId, followerId, followeeId, registerDatetime) <> (AccountFollowingRow.tupled, AccountFollowingRow.unapply)
+    def * = (accountFollowingId, followerId, followeeId, registerDatetime) <> (AccountFollowingRow.tupled, AccountFollowingRow.unapply)
     /** Maps whole row to an option. Useful for outer joins. */
-    def ? = (Rep.Some(memberFollowingId), Rep.Some(followerId), Rep.Some(followeeId), Rep.Some(registerDatetime)).shaped.<>({r=>import r._; _1.map(_=> AccountFollowingRow.tupled((_1.get, _2.get, _3.get, _4.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
+    def ? = (Rep.Some(accountFollowingId), Rep.Some(followerId), Rep.Some(followeeId), Rep.Some(registerDatetime)).shaped.<>({r=>import r._; _1.map(_=> AccountFollowingRow.tupled((_1.get, _2.get, _3.get, _4.get)))}, (_:Any) =>  throw new Exception("Inserting into ? projection not supported."))
 
-    /** Database column MEMBER_FOLLOWING_ID SqlType(BIGINT), AutoInc, PrimaryKey */
-    val memberFollowingId: Rep[Long] = column[Long]("MEMBER_FOLLOWING_ID", O.AutoInc, O.PrimaryKey)
+    /** Database column ACCOUNT_FOLLOWING_ID SqlType(BIGINT), PrimaryKey */
+    val accountFollowingId: Rep[Long] = column[Long]("ACCOUNT_FOLLOWING_ID", O.PrimaryKey)
     /** Database column FOLLOWER_ID SqlType(BIGINT) */
     val followerId: Rep[Long] = column[Long]("FOLLOWER_ID")
     /** Database column FOLLOWEE_ID SqlType(BIGINT) */

--- a/app/repositories/AccountRepositoryJDBC.scala
+++ b/app/repositories/AccountRepositoryJDBC.scala
@@ -4,7 +4,7 @@ import java.sql.Timestamp
 import java.time.LocalDateTime
 import javax.inject.Inject
 import formats.{AccountCreateCommand, AccountUpdateCommand, AccountView}
-import models.Tables.{Account, AccountFollowing, AccountRow}
+import models.Tables.{Account, AccountFollowing, AccountRow, AccountTweet}
 import slick.driver.MySQLDriver.api._
 import utils.Consts
 import scala.concurrent.ExecutionContext
@@ -29,7 +29,7 @@ class AccountRepositoryJDBC @Inject()(implicit ec: ExecutionContext) {
     Account
       .filter(_.memberId === memberId)
       .result
-      .map(_.map {a =>
+      .map(_.map { a =>
         AccountView.from(a)
       })
   }
@@ -91,12 +91,21 @@ class AccountRepositoryJDBC @Inject()(implicit ec: ExecutionContext) {
     Account
       .filter(a => (a.accountId === accountId.bind) && (a.memberId === memberId.bind) && (a.versionNo === form.versionNo.bind))
       .map(a => (a.accountName, a.avatar, a.backgroundImage, a.versionNo, a.updateDatetime))
-      .update(form.accountName.get, form.avatar, form.backgroundImage, form.versionNo + 1L, Timestamp.valueOf(LocalDateTime.now))
+      .update(form.accountName.get, form.avatar, form.backgroundImage, form.versionNo + Consts.AutoIncremental, Timestamp.valueOf(LocalDateTime.now))
   }
 
-  def delete(accountId: Long, memberId: Long): DBIO[Int] = {
-    Account
-      .filter(a => a.accountId === accountId.bind && a.memberId === memberId.bind)
-      .delete
+  def delete(accountId: Long, memberId: Long): DBIO[(Int, Int)] = {
+    (for {
+      accountTweetResult <- AccountTweet
+        .filter(at =>
+          (at.accountId === accountId.bind) &&
+          (at.accountId in Account
+            .filter(_.memberId === memberId.bind)
+            .map(_.accountId))
+        ).delete
+      accountResult <- Account
+        .filter(a => a.accountId === accountId.bind && a.memberId === memberId.bind)
+        .delete
+    } yield (accountTweetResult, accountResult)).transactionally
   }
 }

--- a/app/repositories/AccountRepositoryJDBC.scala
+++ b/app/repositories/AccountRepositoryJDBC.scala
@@ -25,6 +25,15 @@ class AccountRepositoryJDBC @Inject()(implicit ec: ExecutionContext) {
       })
   }
 
+  def listByMemberId(memberId: Long): DBIO[Seq[AccountView]] = {
+    Account
+      .filter(_.memberId === memberId)
+      .result
+      .map(_.map {a =>
+        AccountView.from(a)
+      })
+  }
+
   def listFollowers(accountId: Long): DBIO[Seq[AccountView]] = {
     Account
       .join(AccountFollowing)

--- a/app/repositories/MemberRepositoryJDBC.scala
+++ b/app/repositories/MemberRepositoryJDBC.scala
@@ -8,7 +8,6 @@ import models.Tables.{Account, AccountTweet, Member}
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import slick.driver.MySQLDriver.api._
 import models.Tables.{AccountRow, MemberRow}
-import security.AuthenticatedRequest
 import utils.Consts
 import scala.concurrent.ExecutionContext
 
@@ -64,14 +63,14 @@ class MemberRepositoryJDBC @Inject()(val bCrypt: BCryptPasswordEncoder)(implicit
       }
   }
 
-  def findByTweetId(tweetId: Long)(implicit rs: AuthenticatedRequest[_]): DBIO[Option[Member#TableElementType]] = {
+  def findByTweetId(tweetId: Long, memberId: Long): DBIO[Option[Member#TableElementType]] = {
     val subAccount = Account.join(
       AccountTweet
     ).on { case (a, at) => a.accountId === at.accountId }
     Member.join(subAccount)
       .on { case (m, (a, _)) => m.memberId === a.memberId }
       .filter { case (m, (_, t)) =>
-        (m.memberId === rs.memberId.bind) && (t.tweetId === tweetId.bind)
+        (m.memberId === memberId.bind) && (t.tweetId === tweetId.bind)
       }
       .result
       .headOption

--- a/app/repositories/MemberRepositoryJDBC.scala
+++ b/app/repositories/MemberRepositoryJDBC.scala
@@ -4,10 +4,11 @@ import java.sql.Timestamp
 import java.time.LocalDateTime
 import javax.inject.Inject
 import formats.{AccountView, MemberCommand, MemberView}
-import models.Tables.{Account, Member}
+import models.Tables.{Account, AccountTweet, Member}
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import slick.driver.MySQLDriver.api._
 import models.Tables.{AccountRow, MemberRow}
+import security.AuthenticatedRequest
 import utils.Consts
 import scala.concurrent.ExecutionContext
 
@@ -57,9 +58,25 @@ class MemberRepositoryJDBC @Inject()(val bCrypt: BCryptPasswordEncoder)(implicit
       .map { rows =>
         val member = rows.map(_._1).headOption
         val accounts = rows.map(_._2).map(AccountView.from)
-        member.map{ member =>
+        member.map { member =>
           MemberView.from(member, accounts)
         }
       }
+  }
+
+  def findByTweetId(tweetId: Long)(implicit rs: AuthenticatedRequest[_]): DBIO[Option[Member#TableElementType]] = {
+    val subAccount = Account.join(
+      AccountTweet
+    ).on { case (a, at) => a.accountId === at.accountId }
+    Member.join(subAccount)
+      .on { case (m, (a, _)) => m.memberId === a.memberId }
+      .filter { case (m, (_, t)) =>
+        (m.memberId === rs.memberId.bind) && (t.tweetId === tweetId.bind)
+      }
+      .result
+      .headOption
+      .map(_.map { case (m, _) =>
+        m
+      })
   }
 }

--- a/app/services/AccountService.scala
+++ b/app/services/AccountService.scala
@@ -45,7 +45,7 @@ class AccountService @Inject()(val accountJdbc: AccountRepositoryJDBC, val dbCon
     db.run(accountJdbc.update(accountId, rs.memberId, form))
   }
 
-  def delete(accountId: Long)(implicit rs: AuthenticatedRequest[AnyContent]): Future[Int] = {
+  def delete(accountId: Long)(implicit rs: AuthenticatedRequest[AnyContent]): Future[(Int, Int)] = {
     db.run(accountJdbc.delete(accountId, rs.memberId))
   }
 }

--- a/app/services/AccountService.scala
+++ b/app/services/AccountService.scala
@@ -21,6 +21,10 @@ class AccountService @Inject()(val accountJdbc: AccountRepositoryJDBC, val dbCon
     db.run(accountJdbc.search(form.keyword))
   }
 
+  def listByMemberId(memberId: Long): Future[Seq[AccountView]] = {
+    db.run(accountJdbc.listByMemberId(memberId))
+  }
+
   def listFollowers(accountId: Long): Future[Seq[AccountView]] = {
     db.run(accountJdbc.listFollowers(accountId))
   }

--- a/app/services/MemberService.scala
+++ b/app/services/MemberService.scala
@@ -3,11 +3,12 @@ package services
 import javax.inject.Inject
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import formats.{MemberCommand, MemberView}
-import play.api.mvc.{AnyContent, Request}
+import play.api.mvc.Request
 import repositories.MemberRepositoryJDBC
 import models.Tables.Member
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import play.api.cache.CacheApi
+import security.AuthenticatedRequest
 import scala.concurrent.{ExecutionContext, Future}
 import slick.driver.JdbcProfile
 
@@ -37,6 +38,10 @@ class MemberService @Inject()(val memberJdbc: MemberRepositoryJDBC, val dbConfig
       token <- rs.session.get("token")
       memberId <- cache.get[Long](token)
     } yield memberId
+  }
+
+  def findByTweetId(tweetId: Long)(implicit rs: AuthenticatedRequest[_]): Future[Option[Member#TableElementType]] = {
+    db.run(memberJdbc.findByTweetId(tweetId))
   }
 
   def findCurrentWithAccounts(implicit rs: Request[_]): Future[Option[MemberView]] = {

--- a/app/services/MemberService.scala
+++ b/app/services/MemberService.scala
@@ -41,7 +41,7 @@ class MemberService @Inject()(val memberJdbc: MemberRepositoryJDBC, val dbConfig
   }
 
   def findByTweetId(tweetId: Long)(implicit rs: AuthenticatedRequest[_]): Future[Option[Member#TableElementType]] = {
-    db.run(memberJdbc.findByTweetId(tweetId))
+    db.run(memberJdbc.findByTweetId(tweetId, rs.memberId))
   }
 
   def findCurrentWithAccounts(implicit rs: Request[_]): Future[Option[MemberView]] = {

--- a/app/services/TweetService.scala
+++ b/app/services/TweetService.scala
@@ -1,10 +1,14 @@
 package services
 
 import javax.inject.Inject
+
 import formats.{TweetCommand, TweetView}
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
+import play.api.mvc.AnyContent
 import repositories.TweetRepositoryJDBC
-import scala.concurrent.Future
+import security.AuthenticatedRequest
+
+import scala.concurrent.{ExecutionContext, Future}
 import slick.driver.JdbcProfile
 
 /**
@@ -12,10 +16,19 @@ import slick.driver.JdbcProfile
   *
   * @author yuito.sato
   */
-class TweetService @Inject()(val tweetJdbc: TweetRepositoryJDBC, val dbConfigProvider: DatabaseConfigProvider) extends HasDatabaseConfigProvider[JdbcProfile] {
+class TweetService @Inject()(val tweetJdbc: TweetRepositoryJDBC, val accountService: AccountService, val dbConfigProvider: DatabaseConfigProvider)(implicit ec: ExecutionContext) extends HasDatabaseConfigProvider[JdbcProfile] {
 
-  def list(): Future[Seq[TweetView]] = {
-    db.run(tweetJdbc.list())
+  def list(accountId: Long)(implicit rs: AuthenticatedRequest[AnyContent]): Future[Seq[TweetView]] = {
+    for {
+      accounts <- accountService.listByMemberId(rs.memberId)
+      tweets <- {
+        if (accounts.map(a => a.accountId).contains(accountId)) {
+          db.run(tweetJdbc.list(accountId, rs.memberId))
+        } else {
+          Future.failed(new IllegalArgumentException("不正なアカウントIDです。"))
+        }
+      }
+    } yield tweets
   }
 
   def find(tweetId: Long): Future[Option[TweetView]] = {

--- a/app/services/TweetService.scala
+++ b/app/services/TweetService.scala
@@ -1,14 +1,12 @@
 package services
 
 import javax.inject.Inject
-
 import formats.{TweetCreateCommand, TweetUpdateCommand, TweetView}
 import play.api.db.slick.{DatabaseConfigProvider, HasDatabaseConfigProvider}
 import play.api.libs.json.JsValue
 import play.api.mvc.AnyContent
 import repositories.TweetRepositoryJDBC
 import security.AuthenticatedRequest
-
 import scala.concurrent.{ExecutionContext, Future}
 import slick.driver.JdbcProfile
 
@@ -17,7 +15,7 @@ import slick.driver.JdbcProfile
   *
   * @author yuito.sato
   */
-class TweetService @Inject()(val tweetJdbc: TweetRepositoryJDBC, val accountService: AccountService, val dbConfigProvider: DatabaseConfigProvider)(implicit ec: ExecutionContext) extends HasDatabaseConfigProvider[JdbcProfile] {
+class TweetService @Inject()(val tweetJdbc: TweetRepositoryJDBC, val accountService: AccountService, val memberService: MemberService, val dbConfigProvider: DatabaseConfigProvider)(implicit ec: ExecutionContext) extends HasDatabaseConfigProvider[JdbcProfile] {
 
   def list(accountId: Long)(implicit rs: AuthenticatedRequest[AnyContent]): Future[Seq[TweetView]] = {
     for {
@@ -50,10 +48,28 @@ class TweetService @Inject()(val tweetJdbc: TweetRepositoryJDBC, val accountServ
   }
 
   def update(tweetId: Long, form: TweetUpdateCommand)(implicit rs: AuthenticatedRequest[JsValue]): Future[Int] = {
-    db.run(tweetJdbc.update(tweetId, form))
+    for {
+      member <- memberService.findByTweetId(tweetId)
+      result <- {
+        if (member.nonEmpty) {
+          db.run(tweetJdbc.update(tweetId, form))
+        } else {
+          Future.failed(new IllegalArgumentException("ツイートを更新する権限がありません"))
+        }
+      }
+    } yield result
   }
 
-  def delete(tweetId: Long)(implicit rs: AuthenticatedRequest[AnyContent]): Future[Unit] = {
-    db.run(tweetJdbc.delete(tweetId))
+  def delete(tweetId: Long)(implicit rs: AuthenticatedRequest[AnyContent]): Future[(Int, Int)] = {
+    for {
+      member <- memberService.findByTweetId(tweetId)
+      result <- {
+        if (member.nonEmpty) {
+          db.run(tweetJdbc.delete(tweetId))
+        } else {
+          Future.failed(new IllegalArgumentException("ツイートを削除する権限がありません"))
+        }
+      }
+    } yield result
   }
 }

--- a/app/services/TweetService.scala
+++ b/app/services/TweetService.scala
@@ -53,7 +53,7 @@ class TweetService @Inject()(val tweetJdbc: TweetRepositoryJDBC, val accountServ
     db.run(tweetJdbc.update(tweetId, form))
   }
 
-  def delete(tweetId: Long): Future[(Int, Int)] = {
+  def delete(tweetId: Long)(implicit rs: AuthenticatedRequest[AnyContent]): Future[Unit] = {
     db.run(tweetJdbc.delete(tweetId))
   }
 }

--- a/app/utils/Consts.scala
+++ b/app/utils/Consts.scala
@@ -16,4 +16,5 @@ object Consts {
   val AccountNameMaxLength = 50
   val ImageMaxLength = 200
   val CacheRetentionPeriod: FiniteDuration = 30.days
+  val AutoIncremental = 1L
 }

--- a/app/utils/Consts.scala
+++ b/app/utils/Consts.scala
@@ -17,4 +17,5 @@ object Consts {
   val ImageMaxLength = 200
   val CacheRetentionPeriod: FiniteDuration = 30.days
   val AutoIncremental = 1L
+  val TweetTextMaxLength = 140
 }

--- a/conf/routes
+++ b/conf/routes
@@ -10,7 +10,7 @@ GET           /                                         controllers.HomeControll
 GET           /assets/*file                             controllers.Assets.versioned(path="/public", file: Asset)
 
 # TweetAPI
-GET           /api/tweets                               controllers.TweetController.list
+GET           /api/tweets/:accountId                    controllers.TweetController.list(accountId: Long)
 GET           /api/tweets/:tweetId                      controllers.TweetController.find(tweetId: Long)
 POST          /api/tweets                               controllers.TweetController.create
 PUT           /api/tweets/:tweetId                      controllers.TweetController.update(tweetId: Long)


### PR DESCRIPTION
# 概要
- タイムラインのツイートはフォローしている会員のみを表示
- 自分のアカウントでしかツイートCRUD処理ができないように
- ログイン認証をする
- フォロー機能
- アンフォロー機能
- ユーザー検索でフォロー情報も付加する
- ツイート更新でバージョンナンバーを上げる
- ツイートの文字数指定
- 画像投稿